### PR TITLE
Merge tag-based target blocks for ore gen

### DIFF
--- a/src/main/java/com/veteam/voluminousenergy/VoluminousEnergy.java
+++ b/src/main/java/com/veteam/voluminousenergy/VoluminousEnergy.java
@@ -33,6 +33,7 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.core.BlockPos;
 import net.minecraft.data.DataGenerator;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.tags.BlockTags;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
@@ -94,6 +95,7 @@ public class VoluminousEnergy {
 
         // Config Files to load
         Config.loadConfig(Config.COMMON_CONFIG, FMLPaths.CONFIGDIR.get().resolve("voluminousenergy-common.toml"));
+        VEOreGeneration.OreTags.init();
     }
 
     private void setup(final FMLCommonSetupEvent event) {

--- a/src/main/java/com/veteam/voluminousenergy/VoluminousEnergy.java
+++ b/src/main/java/com/veteam/voluminousenergy/VoluminousEnergy.java
@@ -33,7 +33,6 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.core.BlockPos;
 import net.minecraft.data.DataGenerator;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.tags.BlockTags;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
@@ -95,7 +94,6 @@ public class VoluminousEnergy {
 
         // Config Files to load
         Config.loadConfig(Config.COMMON_CONFIG, FMLPaths.CONFIGDIR.get().resolve("voluminousenergy-common.toml"));
-        VEOreGeneration.OreTags.init();
     }
 
     private void setup(final FMLCommonSetupEvent event) {

--- a/src/main/java/com/veteam/voluminousenergy/util/MultiBlockStateMatchRuleTest.java
+++ b/src/main/java/com/veteam/voluminousenergy/util/MultiBlockStateMatchRuleTest.java
@@ -3,6 +3,7 @@ package com.veteam.voluminousenergy.util;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.structure.templatesystem.BlockStateMatchTest;
 
+import java.util.ArrayList;
 import java.util.Random;
 
 public class MultiBlockStateMatchRuleTest extends BlockStateMatchTest {
@@ -13,10 +14,18 @@ public class MultiBlockStateMatchRuleTest extends BlockStateMatchTest {
         this.stateList = states;
     }
 
+    public MultiBlockStateMatchRuleTest(ArrayList<BlockState> stateList){
+        super(stateList.get(0));
+        this.stateList = new BlockState[stateList.size()];
+        for (int i = 0; i < stateList.size(); i++){
+            this.stateList[i] = stateList.get(i);
+        }
+    }
+
     @Override
-    public boolean test(BlockState p_215181_1_, Random p_215181_2_) {
+    public boolean test(BlockState blockState, Random random) {
         for (BlockState state : stateList){
-            if (state.getBlock() == p_215181_1_.getBlock()){
+            if (state.getBlock() == blockState.getBlock()){
                 return true;
             }
         }

--- a/src/main/java/com/veteam/voluminousenergy/util/RecipeUtil.java
+++ b/src/main/java/com/veteam/voluminousenergy/util/RecipeUtil.java
@@ -21,14 +21,17 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-public class RecipeUtil {
+public class RecipeUtil { // TODO: Remove Tag stuff from here into TagUtil
 
+
+    @Deprecated // USE TagUtil#getFluidTagFromResourceLocation INSTEAD
     public static Tag<Fluid> getTagFromResourceLocationForFluids(ResourceLocation fluidTagLocation, String friendlyRecipeNameOnError){
         return SerializationTags.getInstance().getTagOrThrow(Registry.FLUID_REGISTRY, fluidTagLocation, (tempTag) -> {
             return new JsonSyntaxException("Invalid item tag for second input in the " + friendlyRecipeNameOnError + " Recipe. The offending tag is: '" + tempTag + "'");
         });
     }
 
+    @Deprecated // USE TagUtil#getItemTagFromResourceLocation INSTEAD
     public static Tag<Item> getTagFromResourceLocationForItems(ResourceLocation itemTagLocation, String friendlyRecipeNameOnError){
         return SerializationTags.getInstance().getTagOrThrow(Registry.ITEM_REGISTRY, itemTagLocation, (tempTag) -> {
             return new JsonSyntaxException("Invalid item tag for second input in the " + friendlyRecipeNameOnError + " Recipe. The offending tag is: '" + tempTag + "'");

--- a/src/main/java/com/veteam/voluminousenergy/util/TagUtil.java
+++ b/src/main/java/com/veteam/voluminousenergy/util/TagUtil.java
@@ -3,14 +3,17 @@ package com.veteam.voluminousenergy.util;
 import com.google.gson.JsonSyntaxException;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.tags.*;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.tags.SerializationTags;
+import net.minecraft.tags.Tag;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraftforge.common.ForgeTagHandler;
 import net.minecraftforge.common.Tags;
 import net.minecraftforge.registries.ForgeRegistries;
-import net.minecraftforge.registries.IForgeRegistry;
+
+import java.util.function.Function;
 
 public class TagUtil {
 
@@ -32,10 +35,22 @@ public class TagUtil {
         });
     }
 
-    public static Tag.Named<Block> getStaticBlockTagFromResourceLocation(String blockTagLocation, String stackTraceMessageOnError){ // Doesn't work
-        StaticTagHelper<Block> staticTagHelper = StaticTags.create(Registry.BLOCK_REGISTRY, "tags/blocks");
-        Tag.Named<Block> namedBlockTag = staticTagHelper.bind(blockTagLocation);
+    public static Tag.Named<Block> getStaticBlockTagFromResourceLocation(String blockTagLocation){ // Doesn't work
+        //StaticTagHelper<Block> staticTagHelper = StaticTags.create(Registry.BLOCK_REGISTRY, blockTagLocation);
+        Tag.Named<Block> namedBlockTag = BlockTags.bind(blockTagLocation);
         return namedBlockTag;
+    }
+
+    public static <T> Tag.Named<T> tagger(Function<ResourceLocation, Tag.Named<T>> wrapperFactory, String namespace, String path) {
+        return wrapperFactory.apply(new ResourceLocation(namespace, path));
+    }
+
+    public static <T> Tag.Named<T> taggerNamespacePredefined(Function<ResourceLocation, Tag.Named<T>> wrapperFactory, String completePath) {
+        return wrapperFactory.apply(new ResourceLocation(completePath));
+    }
+
+    public static Tag.Named<Block> forgeSpaceBlockTag(String target){
+        return taggerNamespacePredefined(BlockTags::createOptional, target);
     }
 
     // Use for things like ores

--- a/src/main/java/com/veteam/voluminousenergy/util/TagUtil.java
+++ b/src/main/java/com/veteam/voluminousenergy/util/TagUtil.java
@@ -1,0 +1,45 @@
+package com.veteam.voluminousenergy.util;
+
+import com.google.gson.JsonSyntaxException;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.*;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.material.Fluid;
+import net.minecraftforge.common.ForgeTagHandler;
+import net.minecraftforge.common.Tags;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.IForgeRegistry;
+
+public class TagUtil {
+
+    public static Tag<Fluid> getFluidTagFromResourceLocation(ResourceLocation fluidTagLocation, String stackTraceMessageOnError){
+        return SerializationTags.getInstance().getTagOrThrow(Registry.FLUID_REGISTRY, fluidTagLocation, (tempTag) -> {
+            return new JsonSyntaxException("Invalid ResourceLocation for getFluidTagFromResourceLocation passed by: " + stackTraceMessageOnError + "; The offending tag is: '" + tempTag + "'");
+        });
+    }
+
+    public static Tag<Item> getItemTagFromResourceLocation(ResourceLocation itemTagLocation, String stackTraceMessageOnError){
+        return SerializationTags.getInstance().getTagOrThrow(Registry.ITEM_REGISTRY, itemTagLocation, (tempTag) -> {
+            return new JsonSyntaxException("Invalid ResourceLocation for getItemTagFromResourceLocation passed by: " + stackTraceMessageOnError + "; The offending tag is: '" + tempTag + "'");
+        });
+    }
+
+    public static Tag<Block> getBlockTagFromResourceLocation(ResourceLocation blockTagLocation, String stackTraceMessageOnError){
+        return SerializationTags.getInstance().getTagOrThrow(Registry.BLOCK_REGISTRY, blockTagLocation, (tempTag) -> {
+            return new JsonSyntaxException("Invalid ResourceLocation for getBlockTagFromResourceLocation passed by: " + stackTraceMessageOnError + "; The offending tag is: '" + tempTag + "'");
+        });
+    }
+
+    public static Tag.Named<Block> getStaticBlockTagFromResourceLocation(String blockTagLocation, String stackTraceMessageOnError){ // Doesn't work
+        StaticTagHelper<Block> staticTagHelper = StaticTags.create(Registry.BLOCK_REGISTRY, "tags/blocks");
+        Tag.Named<Block> namedBlockTag = staticTagHelper.bind(blockTagLocation);
+        return namedBlockTag;
+    }
+
+    // Use for things like ores
+    public static Tags.IOptionalNamedTag<Block> getIOptionalNamedBlockTagFromResourceLocation(ResourceLocation blockTagLocation){
+        return ForgeTagHandler.createOptionalTag(ForgeRegistries.BLOCKS, blockTagLocation);
+    }
+}

--- a/src/main/java/com/veteam/voluminousenergy/world/ores/VEOreGeneration.java
+++ b/src/main/java/com/veteam/voluminousenergy/world/ores/VEOreGeneration.java
@@ -7,6 +7,7 @@ import com.veteam.voluminousenergy.util.MultiBlockStateMatchRuleTest;
 import com.veteam.voluminousenergy.util.TagUtil;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
+import net.minecraft.tags.Tag;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
@@ -179,5 +180,10 @@ public class VEOreGeneration {
 
             return new MultiBlockStateMatchRuleTest(taggedStateList);
         }
+    }
+
+    public static class OreTags {
+        public static void init(){}
+        public static final Tag.Named<Block> COLORLESS_SAND = BlockTags.bind("forge:ore_bearing_ground/colorless_sand");
     }
 }

--- a/src/main/java/com/veteam/voluminousenergy/world/ores/VEOreGeneration.java
+++ b/src/main/java/com/veteam/voluminousenergy/world/ores/VEOreGeneration.java
@@ -4,11 +4,13 @@ import com.veteam.voluminousenergy.VoluminousEnergy;
 import com.veteam.voluminousenergy.blocks.blocks.VEBlocks;
 import com.veteam.voluminousenergy.tools.Config;
 import com.veteam.voluminousenergy.util.MultiBlockStateMatchRuleTest;
+import com.veteam.voluminousenergy.util.TagUtil;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.world.level.biome.Biome;
-import net.minecraft.world.level.biome.Biomes;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.GenerationStep;
 import net.minecraft.world.level.levelgen.VerticalAnchor;
 import net.minecraft.world.level.levelgen.feature.Feature;
@@ -16,9 +18,12 @@ import net.minecraft.world.level.levelgen.feature.configurations.OreConfiguratio
 import net.minecraft.world.level.levelgen.placement.*;
 import net.minecraft.world.level.levelgen.structure.templatesystem.RuleTest;
 import net.minecraft.world.level.levelgen.structure.templatesystem.TagMatchTest;
+import net.minecraftforge.common.Tags;
 import net.minecraftforge.event.world.BiomeLoadingEvent;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class VEOreGeneration {
 
@@ -118,8 +123,8 @@ public class VEOreGeneration {
 
     public static class OreWithTargetStatesToReplace {
         public static final List<OreConfiguration.TargetBlockState> SALTPETER_ORE_TARGETS = List.of(
-                OreConfiguration.target(new MultiBlockStateMatchRuleTest(Blocks.SAND.defaultBlockState()), VEBlocks.SALTPETER_ORE.defaultBlockState()),
-                OreConfiguration.target(new MultiBlockStateMatchRuleTest(Blocks.RED_SAND.defaultBlockState()), VEBlocks.RED_SALTPETER_ORE.defaultBlockState())
+                OreConfiguration.target(ReplacementRules.COLORLESS_SAND, VEBlocks.SALTPETER_ORE.defaultBlockState()),
+                OreConfiguration.target(ReplacementRules.RED_SAND, VEBlocks.RED_SALTPETER_ORE.defaultBlockState())
         );
 
         public static final List<OreConfiguration.TargetBlockState> BAUXITE_ORE_TARGETS = List.of(
@@ -142,7 +147,9 @@ public class VEOreGeneration {
                 OreConfiguration.target(ReplacementRules.DEEPSLATE_STONE, VEBlocks.DEEPSLATE_RUTILE_ORE.defaultBlockState())
         );
 
-        public static final List<OreConfiguration.TargetBlockState> EIGHZO_ORE_TARGETS = List.of(OreConfiguration.target(ReplacementRules.END, VEBlocks.EIGHZO_ORE.defaultBlockState()));
+        public static final List<OreConfiguration.TargetBlockState> EIGHZO_ORE_TARGETS = List.of(
+                OreConfiguration.target(ReplacementRules.END, VEBlocks.EIGHZO_ORE.defaultBlockState())
+        );
 
     }
 
@@ -153,8 +160,24 @@ public class VEOreGeneration {
     public static final class ReplacementRules { // These are rule tests to see if the block in the world (inside the biome) is valid to be replaced with the generated ore
         public static final RuleTest REGULAR_STONE = new TagMatchTest(BlockTags.STONE_ORE_REPLACEABLES);
         public static final RuleTest DEEPSLATE_STONE = new TagMatchTest(BlockTags.DEEPSLATE_ORE_REPLACEABLES);
-        public static final RuleTest NETHER = new MultiBlockStateMatchRuleTest(Blocks.NETHERRACK.defaultBlockState(), Blocks.SOUL_SAND.defaultBlockState());
+
+        public static final RuleTest COLORLESS_SAND = createRuleFromTag("forge:ore_bearing_ground/colorless_sand");
+        public static final RuleTest RED_SAND = createRuleFromTag("forge:ore_bearing_ground/red_sand");
+        public static final RuleTest NETHER = createRuleFromTag("forge:ore_bearing_ground/netherrack");
+        public static final RuleTest END = createRuleFromTag("forge:ore_bearing_ground/end_stone");
+
+        // WARN: Not tag based
         public static final RuleTest TERRACOTTA = new MultiBlockStateMatchRuleTest(Blocks.TERRACOTTA.defaultBlockState(), Blocks.WHITE_TERRACOTTA.defaultBlockState(), Blocks.ORANGE_TERRACOTTA.defaultBlockState(), Blocks.MAGENTA_TERRACOTTA.defaultBlockState(), Blocks.LIGHT_BLUE_TERRACOTTA.defaultBlockState(), Blocks.YELLOW_TERRACOTTA.defaultBlockState(), Blocks.LIME_TERRACOTTA.defaultBlockState(), Blocks.PINK_TERRACOTTA.defaultBlockState(), Blocks.GRAY_TERRACOTTA.defaultBlockState(), Blocks.LIGHT_GRAY_TERRACOTTA.defaultBlockState(), Blocks.CYAN_TERRACOTTA.defaultBlockState(), Blocks.PURPLE_TERRACOTTA.defaultBlockState(), Blocks.BLUE_TERRACOTTA.defaultBlockState(), Blocks.BROWN_TERRACOTTA.defaultBlockState(), Blocks.GREEN_TERRACOTTA.defaultBlockState(), Blocks.RED_TERRACOTTA.defaultBlockState(), Blocks.BLACK_TERRACOTTA.defaultBlockState());
-        public static final RuleTest END = new MultiBlockStateMatchRuleTest(Blocks.END_STONE.defaultBlockState());
+
+        public static RuleTest createRuleFromTag(String blockTagLocation){ // TODO: Figure out how to bind tags properly?
+            //BlockTags.bind(blockTagLocation);
+            Tags.IOptionalNamedTag<Block> blockTag = TagUtil.getIOptionalNamedBlockTagFromResourceLocation(new ResourceLocation(blockTagLocation));
+
+            ArrayList<BlockState> taggedStateList = new ArrayList<>();
+            AtomicReference<ArrayList<BlockState>> atomicStateList = new AtomicReference<>(taggedStateList);
+            blockTag.getValues().forEach(block -> atomicStateList.get().add(block.defaultBlockState()));
+
+            return new MultiBlockStateMatchRuleTest(taggedStateList);
+        }
     }
 }

--- a/src/main/java/com/veteam/voluminousenergy/world/ores/VEOreGeneration.java
+++ b/src/main/java/com/veteam/voluminousenergy/world/ores/VEOreGeneration.java
@@ -7,11 +7,9 @@ import com.veteam.voluminousenergy.util.MultiBlockStateMatchRuleTest;
 import com.veteam.voluminousenergy.util.TagUtil;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
-import net.minecraft.tags.Tag;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.GenerationStep;
 import net.minecraft.world.level.levelgen.VerticalAnchor;
 import net.minecraft.world.level.levelgen.feature.Feature;
@@ -22,9 +20,7 @@ import net.minecraft.world.level.levelgen.structure.templatesystem.TagMatchTest;
 import net.minecraftforge.common.Tags;
 import net.minecraftforge.event.world.BiomeLoadingEvent;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
 
 public class VEOreGeneration {
 
@@ -170,20 +166,9 @@ public class VEOreGeneration {
         // WARN: Not tag based
         public static final RuleTest TERRACOTTA = new MultiBlockStateMatchRuleTest(Blocks.TERRACOTTA.defaultBlockState(), Blocks.WHITE_TERRACOTTA.defaultBlockState(), Blocks.ORANGE_TERRACOTTA.defaultBlockState(), Blocks.MAGENTA_TERRACOTTA.defaultBlockState(), Blocks.LIGHT_BLUE_TERRACOTTA.defaultBlockState(), Blocks.YELLOW_TERRACOTTA.defaultBlockState(), Blocks.LIME_TERRACOTTA.defaultBlockState(), Blocks.PINK_TERRACOTTA.defaultBlockState(), Blocks.GRAY_TERRACOTTA.defaultBlockState(), Blocks.LIGHT_GRAY_TERRACOTTA.defaultBlockState(), Blocks.CYAN_TERRACOTTA.defaultBlockState(), Blocks.PURPLE_TERRACOTTA.defaultBlockState(), Blocks.BLUE_TERRACOTTA.defaultBlockState(), Blocks.BROWN_TERRACOTTA.defaultBlockState(), Blocks.GREEN_TERRACOTTA.defaultBlockState(), Blocks.RED_TERRACOTTA.defaultBlockState(), Blocks.BLACK_TERRACOTTA.defaultBlockState());
 
-        public static RuleTest createRuleFromTag(String blockTagLocation){ // TODO: Figure out how to bind tags properly?
-            //BlockTags.bind(blockTagLocation);
+        public static RuleTest createRuleFromTag(String blockTagLocation){
             Tags.IOptionalNamedTag<Block> blockTag = TagUtil.getIOptionalNamedBlockTagFromResourceLocation(new ResourceLocation(blockTagLocation));
-
-            ArrayList<BlockState> taggedStateList = new ArrayList<>();
-            AtomicReference<ArrayList<BlockState>> atomicStateList = new AtomicReference<>(taggedStateList);
-            blockTag.getValues().forEach(block -> atomicStateList.get().add(block.defaultBlockState()));
-
-            return new MultiBlockStateMatchRuleTest(taggedStateList);
+            return new TagMatchTest(blockTag);
         }
-    }
-
-    public static class OreTags {
-        public static void init(){}
-        public static final Tag.Named<Block> COLORLESS_SAND = BlockTags.bind("forge:ore_bearing_ground/colorless_sand");
     }
 }


### PR DESCRIPTION
This PR will make it so Saltpeter and Eighzo will use tags, particularly `forge:ore_bearing_ground` to allow Saltpeter and Eighzo to replaced modded Colourless Sand (`forge:ore_bearing_ground/colorless_sand`), Red Sand (`forge:ore_bearing_ground/red_sand`), and End Stone (`forge:ore_bearing_ground/end_stone`) blocks. This is also why the minimum Forge version has been bumped to 39.0.18.