### PR TITLE
1.18 jei move items

### DIFF
--- a/src/main/java/com/veteam/voluminousenergy/blocks/containers/AqueoulizerContainer.java
+++ b/src/main/java/com/veteam/voluminousenergy/blocks/containers/AqueoulizerContainer.java
@@ -24,7 +24,7 @@ import static com.veteam.voluminousenergy.blocks.blocks.VEBlocks.AQUEOULIZER_CON
 public class AqueoulizerContainer extends VoluminousContainer {
 
 
-    private static final int numberOfSlots = 5;
+    public static final int numberOfSlots = 5;
 
     public AqueoulizerContainer(int id, Level world, BlockPos pos, Inventory inventory, Player player) {
         super(AQUEOULIZER_CONTAINER, id);

--- a/src/main/java/com/veteam/voluminousenergy/blocks/containers/BlastFurnaceContainer.java
+++ b/src/main/java/com/veteam/voluminousenergy/blocks/containers/BlastFurnaceContainer.java
@@ -21,7 +21,7 @@ import static com.veteam.voluminousenergy.blocks.blocks.VEBlocks.BLAST_FURNACE_C
 
 public class BlastFurnaceContainer extends VoluminousContainer {
 
-    private static final int NUMBER_OF_SLOTS = 6;
+    public static final int NUMBER_OF_SLOTS = 6;
 
     public BlastFurnaceContainer(int id, Level world, BlockPos pos, Inventory inventory, Player player){
         super(BLAST_FURNACE_CONTAINER,id);

--- a/src/main/java/com/veteam/voluminousenergy/blocks/containers/CentrifugalSeparatorContainer.java
+++ b/src/main/java/com/veteam/voluminousenergy/blocks/containers/CentrifugalSeparatorContainer.java
@@ -21,7 +21,7 @@ import javax.annotation.Nonnull;
 
 public class CentrifugalSeparatorContainer extends VoluminousContainer {
 
-    private static final int NUMBER_OF_SLOTS = 7;
+    public static final int NUMBER_OF_SLOTS = 7;
 
     public CentrifugalSeparatorContainer(int id, Level world, BlockPos pos, Inventory inventory, Player player){
         super(VEBlocks.CENTRIFUGAL_SEPARATOR_CONTAINER,id);

--- a/src/main/java/com/veteam/voluminousenergy/blocks/containers/CompressorContainer.java
+++ b/src/main/java/com/veteam/voluminousenergy/blocks/containers/CompressorContainer.java
@@ -27,7 +27,7 @@ public class CompressorContainer extends VoluminousContainer {
 
         private final Player playerEntity;
         private final IItemHandler playerInventory;
-        private static final int NUMBER_OF_SLOTS = 3;
+        public static final int NUMBER_OF_SLOTS = 3;
 
         public CompressorContainer(int id, Level world, BlockPos pos, Inventory inventory, Player player){
             super(COMPRESSOR_CONTAINER,id);

--- a/src/main/java/com/veteam/voluminousenergy/blocks/containers/CrusherContainer.java
+++ b/src/main/java/com/veteam/voluminousenergy/blocks/containers/CrusherContainer.java
@@ -25,7 +25,7 @@ import static com.veteam.voluminousenergy.blocks.blocks.VEBlocks.CRUSHER_CONTAIN
 public class CrusherContainer extends VoluminousContainer {
 
 
-    private static final int NUMBER_OF_SLOTS = 4;
+    public static final int NUMBER_OF_SLOTS = 4;
 
     public CrusherContainer(int id, Level world, BlockPos pos, Inventory inventory, Player player){
         super(CRUSHER_CONTAINER,id);

--- a/src/main/java/com/veteam/voluminousenergy/blocks/containers/ElectrolyzerContainer.java
+++ b/src/main/java/com/veteam/voluminousenergy/blocks/containers/ElectrolyzerContainer.java
@@ -23,7 +23,7 @@ import javax.annotation.Nonnull;
 
 public class ElectrolyzerContainer extends VoluminousContainer {
 
-    private static final int NUMBER_OF_SLOTS = 7;
+    public static final int NUMBER_OF_SLOTS = 7;
 
     public ElectrolyzerContainer(int id, Level world, BlockPos pos, Inventory inventory, Player player){
         super(VEBlocks.ELECTROLYZER_CONTAINER,id);

--- a/src/main/java/com/veteam/voluminousenergy/blocks/containers/ImplosionCompressorContainer.java
+++ b/src/main/java/com/veteam/voluminousenergy/blocks/containers/ImplosionCompressorContainer.java
@@ -25,7 +25,7 @@ import static com.veteam.voluminousenergy.blocks.blocks.VEBlocks.IMPLOSION_COMPR
 public class ImplosionCompressorContainer extends VoluminousContainer {
 
     private ImplosionCompressorScreen screen;
-    private static final int NUMBER_OF_SLOTS = 4;
+    public static final int NUMBER_OF_SLOTS = 4;
 
     public ImplosionCompressorContainer(int id, Level world, BlockPos pos, Inventory inventory, Player player){
         super(IMPLOSION_COMPRESSOR_CONTAINER,id);

--- a/src/main/java/com/veteam/voluminousenergy/blocks/containers/PrimitiveStirlingGeneratorContainer.java
+++ b/src/main/java/com/veteam/voluminousenergy/blocks/containers/PrimitiveStirlingGeneratorContainer.java
@@ -21,7 +21,7 @@ import static com.veteam.voluminousenergy.blocks.blocks.VEBlocks.PRIMITIVE_STIRL
 
 public class PrimitiveStirlingGeneratorContainer extends VoluminousContainer {
 
-    private static final int NUMBER_OF_SLOTS = 1;
+    public static final int NUMBER_OF_SLOTS = 1;
 
     public PrimitiveStirlingGeneratorContainer(int windowID, Level world, BlockPos pos, Inventory playerInventory, Player player) {
         super(PRIMITIVE_STIRLING_GENERATOR_CONTAINER, windowID);

--- a/src/main/java/com/veteam/voluminousenergy/blocks/containers/StirlingGeneratorContainer.java
+++ b/src/main/java/com/veteam/voluminousenergy/blocks/containers/StirlingGeneratorContainer.java
@@ -22,7 +22,7 @@ import static com.veteam.voluminousenergy.blocks.blocks.VEBlocks.STIRLING_GENERA
 
 public class StirlingGeneratorContainer extends VoluminousContainer {
 
-    private static final int NUMBER_OF_SLOTS = 1;
+    public static final int NUMBER_OF_SLOTS = 1;
 
     public StirlingGeneratorContainer(int id, Level world, BlockPos pos, Inventory inventory, Player player){
         super(STIRLING_GENERATOR_CONTAINER,id);

--- a/src/main/java/com/veteam/voluminousenergy/blocks/containers/ToolingStationContainer.java
+++ b/src/main/java/com/veteam/voluminousenergy/blocks/containers/ToolingStationContainer.java
@@ -32,7 +32,7 @@ import static com.veteam.voluminousenergy.blocks.blocks.VEBlocks.TOOLING_STATION
 
 public class ToolingStationContainer extends VoluminousContainer {
 
-    private static final int NUMBER_OF_SLOTS = 6;
+    public static final int NUMBER_OF_SLOTS = 6;
 
     public ToolingStationContainer(int id, Level world, BlockPos pos, Inventory inventory, Player player) {
         super(TOOLING_STATION_CONTAINER, id);

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/AqueoulizingCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/AqueoulizingCategory.java
@@ -103,8 +103,8 @@ public class AqueoulizingCategory implements IRecipeCategory<AqueoulizerRecipe> 
         IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
         IGuiFluidStackGroup fluidStacks = recipeLayout.getFluidStacks();
 
-        itemStacks.init(0, false, 2, 10);
-        fluidStacks.init(1, false, 25, 11);
+        itemStacks.init(0, true, 2, 10);
+        fluidStacks.init(1, true, 25, 11);
         fluidStacks.init(2, false, 73,11);
 
         // Input

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/CentrifugalAgitationCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/CentrifugalAgitationCategory.java
@@ -94,7 +94,7 @@ public class CentrifugalAgitationCategory implements IRecipeCategory<Centrifugal
     @Override
     public void setRecipe(IRecipeLayout recipeLayout, CentrifugalAgitatorRecipe recipe, IIngredients ingredients) {
         IGuiFluidStackGroup fluidStacks = recipeLayout.getFluidStacks();
-        fluidStacks.init(0, false, 3, 11);
+        fluidStacks.init(0, true, 3, 11);
         fluidStacks.init(1, false, 49, 11);
         fluidStacks.init(2, false, 73,11);
 

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/CentrifugalSeparationCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/CentrifugalSeparationCategory.java
@@ -133,7 +133,7 @@ public class CentrifugalSeparationCategory implements IRecipeCategory<Centrifuga
     @Override
     public void setRecipe(IRecipeLayout recipeLayout, CentrifugalSeparatorRecipe recipe, IIngredients ingredients) {
         IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
-        itemStacks.init(0, false, 5, 20);
+        itemStacks.init(0, true, 5, 20);
         itemStacks.init(1, false, 49, 2);
 
         // Should only be one ingredient...
@@ -153,7 +153,7 @@ public class CentrifugalSeparationCategory implements IRecipeCategory<Centrifuga
 
         // Calculate RNG stack, only if RNG stack exists
         if (recipe.getRngItemSlot0() != null && recipe.getRngItemSlot0().getItem() != Items.AIR){ // Don't create the slot if the slot will be empty!
-            itemStacks.init(2, true, 49, 20);
+            itemStacks.init(2, false, 49, 20);
             tempStack = recipe.getRngItemSlot0();
             Item rngItem = tempStack.getItem();
             ItemStack rngStack = new ItemStack(rngItem, recipe.getOutputRngAmount0());
@@ -161,7 +161,7 @@ public class CentrifugalSeparationCategory implements IRecipeCategory<Centrifuga
         }
 
         if (recipe.getRngItemSlot1() != null && recipe.getRngItemSlot1().getItem() != Items.AIR){ // Don't create the slot if the slot will be empty!
-            itemStacks.init(3, true, 49, 38);
+            itemStacks.init(3, false, 49, 38);
             tempStack = recipe.getRngItemSlot1();
             Item rngItem = tempStack.getItem();
             ItemStack rngStack = new ItemStack(rngItem, recipe.getOutputRngAmount1());
@@ -169,7 +169,7 @@ public class CentrifugalSeparationCategory implements IRecipeCategory<Centrifuga
         }
 
         if (recipe.getRngItemSlot2() != null && recipe.getRngItemSlot2().getItem() != Items.AIR){ // Don't create the slot if the slot will be empty!
-            itemStacks.init(4, true, 49, 56);
+            itemStacks.init(4, false, 49, 56);
             tempStack = recipe.getRngItemSlot2();
             Item rngItem = tempStack.getItem();
             ItemStack rngStack = new ItemStack(rngItem, recipe.getOutputRngAmount2());

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/CombustionCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/CombustionCategory.java
@@ -121,7 +121,7 @@ public class CombustionCategory implements IRecipeCategory<CombustionGeneratorFu
     @Override
     public void setRecipe(IRecipeLayout recipeLayout, CombustionGeneratorFuelRecipe recipe, IIngredients ingredients) {
         IGuiFluidStackGroup fluidStacks = recipeLayout.getFluidStacks();
-        fluidStacks.init(0, false, 12, 1);
+        fluidStacks.init(0, true, 12, 1);
 
         // Setup Oxidizers
         int j = 0;
@@ -144,7 +144,7 @@ public class CombustionCategory implements IRecipeCategory<CombustionGeneratorFu
 
                         // Core / original logic
                         j = orderOxidizers(i,j);
-                        fluidStacks.init(i, false, 3 + j, 46);
+                        fluidStacks.init(i, true, 3 + j, 46);
                         ArrayList<FluidStack> oxidizerList = new ArrayList(CombustionGeneratorOxidizerRecipe.oxidizerRecipes.get(i-1).nsFluidInputList);
                         fluidStacks.set(i, oxidizerList);
                     }
@@ -154,7 +154,7 @@ public class CombustionCategory implements IRecipeCategory<CombustionGeneratorFu
 
                     // Core / original logic
                     j = orderOxidizers(i,j);
-                    fluidStacks.init(i, false, 3 + j, 46);
+                    fluidStacks.init(i, true, 3 + j, 46);
                     ArrayList<FluidStack> oxidizerList = new ArrayList(CombustionGeneratorOxidizerRecipe.oxidizerRecipes.get(i-1).nsFluidInputList);
                     fluidStacks.set(i, oxidizerList);
                 }

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/CompressingCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/CompressingCategory.java
@@ -98,7 +98,7 @@ public class CompressingCategory implements IRecipeCategory<CompressorRecipe> {
     @Override
     public void setRecipe(IRecipeLayout recipeLayout, CompressorRecipe recipe, IIngredients ingredients) {
         IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
-        itemStacks.init(0, false, 2, 10);
+        itemStacks.init(0, true, 2, 10);
         itemStacks.init(1, false, 48, 10);
 
         // Should only be one ingredient...

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/CrushingCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/CrushingCategory.java
@@ -110,7 +110,7 @@ public class CrushingCategory implements IRecipeCategory<CrusherRecipe> {
     @Override
     public void setRecipe(IRecipeLayout recipeLayout, CrusherRecipe recipe, IIngredients ingredients) {
         IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
-        itemStacks.init(0, false, 11, 0);
+        itemStacks.init(0, true, 11, 0);
         itemStacks.init(1, false, 2, 45);
 
         // Should only be one ingredient...
@@ -130,7 +130,7 @@ public class CrushingCategory implements IRecipeCategory<CrusherRecipe> {
 
         // Calculate RNG stack, only if RNG stack exists
         if (recipe.getRngItem() != null && recipe.getRngItem().getItem() != Items.AIR){ // Don't create the slot if the slot will be empty!
-            itemStacks.init(2, true, 20, 45);
+            itemStacks.init(2, false, 20, 45);
             tempStack = recipe.getRngItem();
             Item rngItem = tempStack.getItem();
             ItemStack rngStack = new ItemStack(rngItem, recipe.getOutputRngAmount());

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/DistillingCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/DistillingCategory.java
@@ -99,7 +99,7 @@ public class DistillingCategory implements IRecipeCategory<DistillationRecipe> {
         IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
         IGuiFluidStackGroup fluidStacks = recipeLayout.getFluidStacks();
 
-        fluidStacks.init(0, false, 3,11);
+        fluidStacks.init(0, true, 3,11);
         fluidStacks.init(1, false, 49,11);
         fluidStacks.init(2, false, 73,11);
         itemStacks.init(3,false, 96,10);

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/ElectrolyzingCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/ElectrolyzingCategory.java
@@ -134,7 +134,7 @@ public class ElectrolyzingCategory implements IRecipeCategory<ElectrolyzerRecipe
     @Override
     public void setRecipe(IRecipeLayout recipeLayout, ElectrolyzerRecipe recipe, IIngredients ingredients) {
         IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
-        itemStacks.init(0, false, 5, 20);
+        itemStacks.init(0, true, 5, 20);
         itemStacks.init(1, false, 49, 2);
 
         // Should only be one ingredient...
@@ -154,7 +154,7 @@ public class ElectrolyzingCategory implements IRecipeCategory<ElectrolyzerRecipe
 
         // Calculate RNG stack, only if RNG stack exists
         if (recipe.getRngItemSlot0() != null && recipe.getRngItemSlot0().getItem() != Items.AIR){ // Don't create the slot if the slot will be empty!
-            itemStacks.init(2, true, 49, 20);
+            itemStacks.init(2, false, 49, 20);
             tempStack = recipe.getRngItemSlot0();
             Item rngItem = tempStack.getItem();
             ItemStack rngStack = new ItemStack(rngItem, recipe.getOutputRngAmount0());
@@ -162,7 +162,7 @@ public class ElectrolyzingCategory implements IRecipeCategory<ElectrolyzerRecipe
         }
 
         if (recipe.getRngItemSlot1() != null && recipe.getRngItemSlot1().getItem() != Items.AIR){ // Don't create the slot if the slot will be empty!
-            itemStacks.init(3, true, 49, 38);
+            itemStacks.init(3, false, 49, 38);
             tempStack = recipe.getRngItemSlot1();
             Item rngItem = tempStack.getItem();
             ItemStack rngStack = new ItemStack(rngItem, recipe.getOutputRngAmount1());
@@ -170,7 +170,7 @@ public class ElectrolyzingCategory implements IRecipeCategory<ElectrolyzerRecipe
         }
 
         if (recipe.getRngItemSlot2() != null && recipe.getRngItemSlot2().getItem() != Items.AIR){ // Don't create the slot if the slot will be empty!
-            itemStacks.init(4, true, 49, 56);
+            itemStacks.init(4, false, 49, 56);
             tempStack = recipe.getRngItemSlot2();
             Item rngItem = tempStack.getItem();
             ItemStack rngStack = new ItemStack(rngItem, recipe.getOutputRngAmount2());

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/ImplosionCompressionCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/ImplosionCompressionCategory.java
@@ -100,8 +100,8 @@ public class ImplosionCompressionCategory implements IRecipeCategory<ImplosionCo
     @Override
     public void setRecipe(IRecipeLayout recipeLayout, ImplosionCompressorRecipe recipe, IIngredients ingredients) {
         IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
-        itemStacks.init(0, false, 2, 1);
-        itemStacks.init(2, false, 2, 19);
+        itemStacks.init(0, true, 2, 1);
+        itemStacks.init(2, true, 2, 19);
         itemStacks.init(1, false, 48, 10);
 
         // Should only be one ingredient...

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/IndustrialBlastingCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/IndustrialBlastingCategory.java
@@ -127,10 +127,10 @@ public class IndustrialBlastingCategory implements IRecipeCategory<IndustrialBla
         IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
         IGuiFluidStackGroup fluidStacks = recipeLayout.getFluidStacks();
 
-        itemStacks.init(0, false, 30, 1);
-        itemStacks.init(2, false, 30, 19);
+        itemStacks.init(0, true, 30, 1);
+        itemStacks.init(2, true, 30, 19);
         itemStacks.init(1, false, 78, 10);
-        fluidStacks.init(3, false, 6, 11);
+        fluidStacks.init(3, true, 6, 11);
 
 
         // Should only be one ingredient...

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/StirlingCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/StirlingCategory.java
@@ -87,7 +87,7 @@ public class StirlingCategory implements IRecipeCategory<StirlingGeneratorRecipe
     @Override
     public void setRecipe(IRecipeLayout recipeLayout, StirlingGeneratorRecipe recipe, IIngredients ingredients) {
         IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
-        itemStacks.init(0, false, 11, 0);
+        itemStacks.init(0, true, 11, 0);
 
         // Should only be one ingredient...
         List<ItemStack> inputs = new ArrayList<>();

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/ToolingCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/ToolingCategory.java
@@ -97,8 +97,8 @@ public class ToolingCategory implements IRecipeCategory<ToolingRecipe> {
     public void setRecipe(IRecipeLayout recipeLayout, ToolingRecipe recipe, IIngredients ingredients) {
         IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
         itemStacks.init(0, false, 2, 10); // This is the result / complete multitool
-        itemStacks.init(1, false, 48, 1); // This is the top which should be the bit
-        itemStacks.init(2, false, 48, 19); // This is the bottom which should be the Base
+        itemStacks.init(1, true, 48, 1); // This is the top which should be the bit
+        itemStacks.init(2, true, 48, 19); // This is the bottom which should be the Base
 
         ArrayList<ItemStack> bitList = new ArrayList<>();
         ArrayList<ItemStack> baseList = new ArrayList<>();

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/VoluminousEnergyPlugin.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/VoluminousEnergyPlugin.java
@@ -4,6 +4,7 @@ import com.veteam.voluminousenergy.VoluminousEnergy;
 import com.veteam.voluminousenergy.blocks.blocks.VEBlocks;
 import com.veteam.voluminousenergy.blocks.containers.CompressorContainer;
 import com.veteam.voluminousenergy.blocks.containers.CrusherContainer;
+import com.veteam.voluminousenergy.blocks.containers.ElectrolyzerContainer;
 import com.veteam.voluminousenergy.blocks.containers.PrimitiveStirlingGeneratorContainer;
 import com.veteam.voluminousenergy.blocks.containers.StirlingGeneratorContainer;
 import com.veteam.voluminousenergy.blocks.screens.*;
@@ -121,8 +122,8 @@ public class VoluminousEnergyPlugin implements IModPlugin {
 
     @Override
     public void registerRecipeTransferHandlers(IRecipeTransferRegistration registration) {
-        //registration.addRecipeTransferHandler(ElectrolyzerContainer.class, ELECTROLYZING_UID, 0, 1, 3, 36);
         registration.addRecipeTransferHandler(CrusherContainer.class, CRUSHING_UID, 0, 1, CrusherContainer.NUMBER_OF_SLOTS, 36);
+        registration.addRecipeTransferHandler(ElectrolyzerContainer.class, ELECTROLYZING_UID, 0, 2, ElectrolyzerContainer.NUMBER_OF_SLOTS, 36);
         registration.addRecipeTransferHandler(CompressorContainer.class, COMPRESSING_UID, 0, 1, CompressorContainer.NUMBER_OF_SLOTS, 36);
         registration.addRecipeTransferHandler(PrimitiveStirlingGeneratorContainer.class, STIRLING_UID, 0, 1, PrimitiveStirlingGeneratorContainer.NUMBER_OF_SLOTS, 36);
         registration.addRecipeTransferHandler(StirlingGeneratorContainer.class, STIRLING_UID, 0, 1, StirlingGeneratorContainer.NUMBER_OF_SLOTS, 36);

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/VoluminousEnergyPlugin.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/VoluminousEnergyPlugin.java
@@ -2,6 +2,7 @@ package com.veteam.voluminousenergy.compat.jei;
 
 import com.veteam.voluminousenergy.VoluminousEnergy;
 import com.veteam.voluminousenergy.blocks.blocks.VEBlocks;
+import com.veteam.voluminousenergy.blocks.containers.CompressorContainer;
 import com.veteam.voluminousenergy.blocks.containers.CrusherContainer;
 import com.veteam.voluminousenergy.blocks.containers.PrimitiveStirlingGeneratorContainer;
 import com.veteam.voluminousenergy.blocks.containers.StirlingGeneratorContainer;
@@ -122,6 +123,7 @@ public class VoluminousEnergyPlugin implements IModPlugin {
     public void registerRecipeTransferHandlers(IRecipeTransferRegistration registration) {
         //registration.addRecipeTransferHandler(ElectrolyzerContainer.class, ELECTROLYZING_UID, 0, 1, 3, 36);
         registration.addRecipeTransferHandler(CrusherContainer.class, CRUSHING_UID, 0, 1, CrusherContainer.NUMBER_OF_SLOTS, 36);
+        registration.addRecipeTransferHandler(CompressorContainer.class, COMPRESSING_UID, 0, 1, CompressorContainer.NUMBER_OF_SLOTS, 36);
         registration.addRecipeTransferHandler(PrimitiveStirlingGeneratorContainer.class, STIRLING_UID, 0, 1, PrimitiveStirlingGeneratorContainer.NUMBER_OF_SLOTS, 36);
         registration.addRecipeTransferHandler(StirlingGeneratorContainer.class, STIRLING_UID, 0, 1, StirlingGeneratorContainer.NUMBER_OF_SLOTS, 36);
     }

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/VoluminousEnergyPlugin.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/VoluminousEnergyPlugin.java
@@ -2,6 +2,7 @@ package com.veteam.voluminousenergy.compat.jei;
 
 import com.veteam.voluminousenergy.VoluminousEnergy;
 import com.veteam.voluminousenergy.blocks.blocks.VEBlocks;
+import com.veteam.voluminousenergy.blocks.containers.AqueoulizerContainer;
 import com.veteam.voluminousenergy.blocks.containers.CompressorContainer;
 import com.veteam.voluminousenergy.blocks.containers.CrusherContainer;
 import com.veteam.voluminousenergy.blocks.containers.ElectrolyzerContainer;
@@ -127,6 +128,7 @@ public class VoluminousEnergyPlugin implements IModPlugin {
         registration.addRecipeTransferHandler(CompressorContainer.class, COMPRESSING_UID, 0, 1, CompressorContainer.NUMBER_OF_SLOTS, 36);
         registration.addRecipeTransferHandler(PrimitiveStirlingGeneratorContainer.class, STIRLING_UID, 0, 1, PrimitiveStirlingGeneratorContainer.NUMBER_OF_SLOTS, 36);
         registration.addRecipeTransferHandler(StirlingGeneratorContainer.class, STIRLING_UID, 0, 1, StirlingGeneratorContainer.NUMBER_OF_SLOTS, 36);
+        registration.addRecipeTransferHandler(AqueoulizerContainer.class, AQUEOULIZING_UID, 3, 1, AqueoulizerContainer.numberOfSlots, 36);
     }
 
     @Override

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/VoluminousEnergyPlugin.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/VoluminousEnergyPlugin.java
@@ -11,6 +11,7 @@ import com.veteam.voluminousenergy.blocks.containers.ElectrolyzerContainer;
 import com.veteam.voluminousenergy.blocks.containers.ImplosionCompressorContainer;
 import com.veteam.voluminousenergy.blocks.containers.PrimitiveStirlingGeneratorContainer;
 import com.veteam.voluminousenergy.blocks.containers.StirlingGeneratorContainer;
+import com.veteam.voluminousenergy.blocks.containers.ToolingStationContainer;
 import com.veteam.voluminousenergy.blocks.screens.*;
 import com.veteam.voluminousenergy.fluids.VEFluids;
 import com.veteam.voluminousenergy.recipe.*;
@@ -135,6 +136,7 @@ public class VoluminousEnergyPlugin implements IModPlugin {
         registration.addRecipeTransferHandler(CentrifugalSeparatorContainer.class, CENTRIFUGAL_SEPARATION_UID, 0, 2, CentrifugalSeparatorContainer.NUMBER_OF_SLOTS, 36);
         registration.addRecipeTransferHandler(ImplosionCompressorContainer.class, IMPLOSION_COMPRESSION_UID, 0, 2, ImplosionCompressorContainer.NUMBER_OF_SLOTS, 36);
         registration.addRecipeTransferHandler(BlastFurnaceContainer.class, INDUSTRIAL_BLASTING_UID, 2, 2, BlastFurnaceContainer.NUMBER_OF_SLOTS, 36);
+        registration.addRecipeTransferHandler(ToolingStationContainer.class, TOOLING_UID, 3, 2, ToolingStationContainer.NUMBER_OF_SLOTS, 36);
     }
 
     @Override

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/VoluminousEnergyPlugin.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/VoluminousEnergyPlugin.java
@@ -2,6 +2,7 @@ package com.veteam.voluminousenergy.compat.jei;
 
 import com.veteam.voluminousenergy.VoluminousEnergy;
 import com.veteam.voluminousenergy.blocks.blocks.VEBlocks;
+import com.veteam.voluminousenergy.blocks.containers.PrimitiveStirlingGeneratorContainer;
 import com.veteam.voluminousenergy.blocks.containers.StirlingGeneratorContainer;
 import com.veteam.voluminousenergy.blocks.screens.*;
 import com.veteam.voluminousenergy.fluids.VEFluids;
@@ -120,6 +121,7 @@ public class VoluminousEnergyPlugin implements IModPlugin {
     public void registerRecipeTransferHandlers(IRecipeTransferRegistration registration) {
         //registration.addRecipeTransferHandler(CrusherContainer.class, CRUSHING_UID, 0, 1, 3, 36);
         //registration.addRecipeTransferHandler(ElectrolyzerContainer.class, ELECTROLYZING_UID, 0, 1, 3, 36);
+        registration.addRecipeTransferHandler(PrimitiveStirlingGeneratorContainer.class, STIRLING_UID, 0, 1, PrimitiveStirlingGeneratorContainer.NUMBER_OF_SLOTS, 36);
         registration.addRecipeTransferHandler(StirlingGeneratorContainer.class, STIRLING_UID, 0, 1, StirlingGeneratorContainer.NUMBER_OF_SLOTS, 36);
     }
 

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/VoluminousEnergyPlugin.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/VoluminousEnergyPlugin.java
@@ -2,6 +2,7 @@ package com.veteam.voluminousenergy.compat.jei;
 
 import com.veteam.voluminousenergy.VoluminousEnergy;
 import com.veteam.voluminousenergy.blocks.blocks.VEBlocks;
+import com.veteam.voluminousenergy.blocks.containers.CrusherContainer;
 import com.veteam.voluminousenergy.blocks.containers.PrimitiveStirlingGeneratorContainer;
 import com.veteam.voluminousenergy.blocks.containers.StirlingGeneratorContainer;
 import com.veteam.voluminousenergy.blocks.screens.*;
@@ -119,8 +120,8 @@ public class VoluminousEnergyPlugin implements IModPlugin {
 
     @Override
     public void registerRecipeTransferHandlers(IRecipeTransferRegistration registration) {
-        //registration.addRecipeTransferHandler(CrusherContainer.class, CRUSHING_UID, 0, 1, 3, 36);
         //registration.addRecipeTransferHandler(ElectrolyzerContainer.class, ELECTROLYZING_UID, 0, 1, 3, 36);
+        registration.addRecipeTransferHandler(CrusherContainer.class, CRUSHING_UID, 0, 1, CrusherContainer.NUMBER_OF_SLOTS, 36);
         registration.addRecipeTransferHandler(PrimitiveStirlingGeneratorContainer.class, STIRLING_UID, 0, 1, PrimitiveStirlingGeneratorContainer.NUMBER_OF_SLOTS, 36);
         registration.addRecipeTransferHandler(StirlingGeneratorContainer.class, STIRLING_UID, 0, 1, StirlingGeneratorContainer.NUMBER_OF_SLOTS, 36);
     }

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/VoluminousEnergyPlugin.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/VoluminousEnergyPlugin.java
@@ -3,6 +3,7 @@ package com.veteam.voluminousenergy.compat.jei;
 import com.veteam.voluminousenergy.VoluminousEnergy;
 import com.veteam.voluminousenergy.blocks.blocks.VEBlocks;
 import com.veteam.voluminousenergy.blocks.containers.AqueoulizerContainer;
+import com.veteam.voluminousenergy.blocks.containers.BlastFurnaceContainer;
 import com.veteam.voluminousenergy.blocks.containers.CentrifugalSeparatorContainer;
 import com.veteam.voluminousenergy.blocks.containers.CompressorContainer;
 import com.veteam.voluminousenergy.blocks.containers.CrusherContainer;
@@ -133,6 +134,7 @@ public class VoluminousEnergyPlugin implements IModPlugin {
         registration.addRecipeTransferHandler(AqueoulizerContainer.class, AQUEOULIZING_UID, 3, 1, AqueoulizerContainer.numberOfSlots, 36);
         registration.addRecipeTransferHandler(CentrifugalSeparatorContainer.class, CENTRIFUGAL_SEPARATION_UID, 0, 2, CentrifugalSeparatorContainer.NUMBER_OF_SLOTS, 36);
         registration.addRecipeTransferHandler(ImplosionCompressorContainer.class, IMPLOSION_COMPRESSION_UID, 0, 2, ImplosionCompressorContainer.NUMBER_OF_SLOTS, 36);
+        registration.addRecipeTransferHandler(BlastFurnaceContainer.class, INDUSTRIAL_BLASTING_UID, 2, 2, BlastFurnaceContainer.NUMBER_OF_SLOTS, 36);
     }
 
     @Override

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/VoluminousEnergyPlugin.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/VoluminousEnergyPlugin.java
@@ -2,6 +2,7 @@ package com.veteam.voluminousenergy.compat.jei;
 
 import com.veteam.voluminousenergy.VoluminousEnergy;
 import com.veteam.voluminousenergy.blocks.blocks.VEBlocks;
+import com.veteam.voluminousenergy.blocks.containers.StirlingGeneratorContainer;
 import com.veteam.voluminousenergy.blocks.screens.*;
 import com.veteam.voluminousenergy.fluids.VEFluids;
 import com.veteam.voluminousenergy.recipe.*;
@@ -119,6 +120,7 @@ public class VoluminousEnergyPlugin implements IModPlugin {
     public void registerRecipeTransferHandlers(IRecipeTransferRegistration registration) {
         //registration.addRecipeTransferHandler(CrusherContainer.class, CRUSHING_UID, 0, 1, 3, 36);
         //registration.addRecipeTransferHandler(ElectrolyzerContainer.class, ELECTROLYZING_UID, 0, 1, 3, 36);
+        registration.addRecipeTransferHandler(StirlingGeneratorContainer.class, STIRLING_UID, 0, 1, StirlingGeneratorContainer.NUMBER_OF_SLOTS, 36);
     }
 
     @Override

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/VoluminousEnergyPlugin.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/VoluminousEnergyPlugin.java
@@ -7,6 +7,7 @@ import com.veteam.voluminousenergy.blocks.containers.CentrifugalSeparatorContain
 import com.veteam.voluminousenergy.blocks.containers.CompressorContainer;
 import com.veteam.voluminousenergy.blocks.containers.CrusherContainer;
 import com.veteam.voluminousenergy.blocks.containers.ElectrolyzerContainer;
+import com.veteam.voluminousenergy.blocks.containers.ImplosionCompressorContainer;
 import com.veteam.voluminousenergy.blocks.containers.PrimitiveStirlingGeneratorContainer;
 import com.veteam.voluminousenergy.blocks.containers.StirlingGeneratorContainer;
 import com.veteam.voluminousenergy.blocks.screens.*;
@@ -131,6 +132,7 @@ public class VoluminousEnergyPlugin implements IModPlugin {
         registration.addRecipeTransferHandler(StirlingGeneratorContainer.class, STIRLING_UID, 0, 1, StirlingGeneratorContainer.NUMBER_OF_SLOTS, 36);
         registration.addRecipeTransferHandler(AqueoulizerContainer.class, AQUEOULIZING_UID, 3, 1, AqueoulizerContainer.numberOfSlots, 36);
         registration.addRecipeTransferHandler(CentrifugalSeparatorContainer.class, CENTRIFUGAL_SEPARATION_UID, 0, 2, CentrifugalSeparatorContainer.NUMBER_OF_SLOTS, 36);
+        registration.addRecipeTransferHandler(ImplosionCompressorContainer.class, IMPLOSION_COMPRESSION_UID, 0, 2, ImplosionCompressorContainer.NUMBER_OF_SLOTS, 36);
     }
 
     @Override

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/VoluminousEnergyPlugin.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/VoluminousEnergyPlugin.java
@@ -3,6 +3,7 @@ package com.veteam.voluminousenergy.compat.jei;
 import com.veteam.voluminousenergy.VoluminousEnergy;
 import com.veteam.voluminousenergy.blocks.blocks.VEBlocks;
 import com.veteam.voluminousenergy.blocks.containers.AqueoulizerContainer;
+import com.veteam.voluminousenergy.blocks.containers.CentrifugalSeparatorContainer;
 import com.veteam.voluminousenergy.blocks.containers.CompressorContainer;
 import com.veteam.voluminousenergy.blocks.containers.CrusherContainer;
 import com.veteam.voluminousenergy.blocks.containers.ElectrolyzerContainer;
@@ -129,6 +130,7 @@ public class VoluminousEnergyPlugin implements IModPlugin {
         registration.addRecipeTransferHandler(PrimitiveStirlingGeneratorContainer.class, STIRLING_UID, 0, 1, PrimitiveStirlingGeneratorContainer.NUMBER_OF_SLOTS, 36);
         registration.addRecipeTransferHandler(StirlingGeneratorContainer.class, STIRLING_UID, 0, 1, StirlingGeneratorContainer.NUMBER_OF_SLOTS, 36);
         registration.addRecipeTransferHandler(AqueoulizerContainer.class, AQUEOULIZING_UID, 3, 1, AqueoulizerContainer.numberOfSlots, 36);
+        registration.addRecipeTransferHandler(CentrifugalSeparatorContainer.class, CENTRIFUGAL_SEPARATION_UID, 0, 2, CentrifugalSeparatorContainer.NUMBER_OF_SLOTS, 36);
     }
 
     @Override

--- a/src/main/java/com/veteam/voluminousenergy/recipe/CentrifugalAgitatorRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/CentrifugalAgitatorRecipe.java
@@ -181,7 +181,7 @@ public class CentrifugalAgitatorRecipe extends VEFluidRecipe {
             } else if (inputFluid.has("fluid") && !inputFluid.has("tag")){
                 // In here, a manually defined fluid is used instead of a tag
                 ResourceLocation fluidResourceLocation = ResourceLocation.of(GsonHelper.getAsString(inputFluid,"fluid","minecraft:empty"),':');
-                recipe.inputFluid = new FluidStack(Objects.requireNonNull(ForgeRegistries.FLUIDS.getValue(fluidResourceLocation)),1000);
+                recipe.inputFluid = new FluidStack(Objects.requireNonNull(ForgeRegistries.FLUIDS.getValue(fluidResourceLocation)),recipe.inputAmount);
                 recipe.fluidInputList.add(recipe.inputFluid);
                 recipe.rawFluidInputList.add(recipe.inputFluid.getRawFluid());
                 recipe.inputArraySize = recipe.fluidInputList.size();


### PR DESCRIPTION
1. Fix item/fluid stack's assign input/output (#71)
1. Add move items button to all category

![Animation](https://user-images.githubusercontent.com/44163945/156690002-2377541a-a37e-4a0a-8897-9307fec1a7a0.gif)
![Animation](https://user-images.githubusercontent.com/44163945/156690200-aeb582f1-7d33-43d4-8782-5510df57be63.gif)
![Animation](https://user-images.githubusercontent.com/44163945/156694058-eb825976-f7e3-42d6-8ade-331dd3780285.gif)


1. Move item to each slot as count 1 even if input item's count over 1 (like Electrolyzer), just 1<br>i think, this is jei bug
1. But it don't be problem in Refined Storage pattern encoding

![image](https://user-images.githubusercontent.com/44163945/156694937-acdf93ee-f94f-40a2-8c77-7f25d1efe4e5.png)

![image](https://user-images.githubusercontent.com/44163945/156694793-0c74eb71-da93-4d65-891a-d9eed6f18d83.png)
