### PR TITLE
Rebalance Oil Lakes in 1.18.2

### DIFF
--- a/src/main/java/com/veteam/voluminousenergy/VoluminousEnergy.java
+++ b/src/main/java/com/veteam/voluminousenergy/VoluminousEnergy.java
@@ -745,11 +745,11 @@ public class VoluminousEnergy {
         public static void onRegisterFeature(RegistryEvent.Register<Feature<?>> event) { // REGISTER STRAIGHT UP FEATURES HERE
             // Straight up Features
             event.getRegistry().register(VEFeatures.VE_BSC_LAKE_FEATURE.setRegistryName("ve_bsc_lake_feature"));
+            event.getRegistry().register(VEFeatures.VE_BSC_LAKE_SURFACE_FEATURE.setRegistryName("ve_bsc_surface_lake_feature"));
+            event.getRegistry().register(VEFeatures.VE_BSC_LAKE_UNDERGROUND_FEATURE.setRegistryName("ve_bsc_underground_lakes_feature"));
             event.getRegistry().register(VEFeatures.VE_GEYSER_FEATURE.setRegistryName("ve_geyser_feature"));
             event.getRegistry().register(VEFeatures.VE_RICE_FEATURE.setRegistryName("ve_rice_feature"));
             event.getRegistry().register(VEFeatures.VE_ORE_DEPOSIT_FEATURE.setRegistryName("ve_ore_deposit_feature"));
-            event.getRegistry().register(SurfaceMattersLakesFeature.SURFACE_INSTANCE.setRegistryName("ve_surface_lake_feature"));
-            event.getRegistry().register(SurfaceMattersLakesFeature.UNDERGROUND_INSTANCE.setRegistryName("ve_underground_lakes_feature"));
         }
     }
 

--- a/src/main/java/com/veteam/voluminousenergy/VoluminousEnergy.java
+++ b/src/main/java/com/veteam/voluminousenergy/VoluminousEnergy.java
@@ -29,6 +29,7 @@ import com.veteam.voluminousenergy.setup.VESetup;
 import com.veteam.voluminousenergy.tools.Config;
 import com.veteam.voluminousenergy.tools.networking.VENetwork;
 import com.veteam.voluminousenergy.world.VEFeatureGeneration;
+import com.veteam.voluminousenergy.world.feature.SurfaceMattersLakesFeature;
 import com.veteam.voluminousenergy.world.feature.VEFeatures;
 import com.veteam.voluminousenergy.world.ores.VEOreGeneration;
 import com.veteam.voluminousenergy.world.ores.VEOres;
@@ -747,6 +748,8 @@ public class VoluminousEnergy {
             event.getRegistry().register(VEFeatures.VE_GEYSER_FEATURE.setRegistryName("ve_geyser_feature"));
             event.getRegistry().register(VEFeatures.VE_RICE_FEATURE.setRegistryName("ve_rice_feature"));
             event.getRegistry().register(VEFeatures.VE_ORE_DEPOSIT_FEATURE.setRegistryName("ve_ore_deposit_feature"));
+            event.getRegistry().register(SurfaceMattersLakesFeature.SURFACE_INSTANCE.setRegistryName("ve_surface_lake_feature"));
+            event.getRegistry().register(SurfaceMattersLakesFeature.UNDERGROUND_INSTANCE.setRegistryName("ve_underground_lakes_feature"));
         }
     }
 
@@ -760,7 +763,7 @@ public class VoluminousEnergy {
         builtinConfiguredFeaturesRegistry(VEOres.GALENA_ORE_BLOB, "galena_ore_blob");
 
         // Oil
-        builtinConfiguredFeaturesRegistry(VEFeatures.OIL_LAKE_FEATURE, "oil_lake");
+        builtinConfiguredFeaturesRegistry(VEFeatures.SURFACE_OIL_LAKE_FEATURE, "oil_lake");
         builtinConfiguredFeaturesRegistry(VEFeatures.OIL_GEYSER_FEATURE, "oil_geyser");
 
         // Rice

--- a/src/main/java/com/veteam/voluminousenergy/tools/Config.java
+++ b/src/main/java/com/veteam/voluminousenergy/tools/Config.java
@@ -471,7 +471,7 @@ public class Config {
                 SURFACE_OIL_LAKE_CHANCE = COMMON_BUILDER.comment("Surface Oil Lake Chance (Lower = Higher chance)")
                         .defineInRange("Surface Oil Lake Chance", 144, 10, Integer.MAX_VALUE);
                 UNDERGROUND_OIL_LAKE_CHANCE = COMMON_BUILDER.comment("Underground Oil Lake Chance (Lower = Higher chance)")
-                        .defineInRange("Underground Oil Lake Chance", 16, 10, Integer.MAX_VALUE);
+                        .defineInRange("Underground Oil Lake Chance", 5, 1, Integer.MAX_VALUE);
                 GENERATE_OIL_GEYSER = COMMON_BUILDER.comment("Enable/Disable Oil Geysers")
                         .define("Oil Geysers", true);
                 OIL_GEYSER_CHANCE = COMMON_BUILDER.comment("Oil Geyser Chance (Lower = Higher chance)")

--- a/src/main/java/com/veteam/voluminousenergy/world/feature/SurfaceMattersLakesFeature.java
+++ b/src/main/java/com/veteam/voluminousenergy/world/feature/SurfaceMattersLakesFeature.java
@@ -9,13 +9,13 @@ import net.minecraft.world.level.levelgen.feature.configurations.BlockStateConfi
 
 import java.util.Random;
 
-public class CrudeOilFeature extends VELakesFeature {
-    public static CrudeOilFeature SURFACE_INSTANCE = new CrudeOilFeature(BlockStateConfiguration.CODEC, true);
-    public static CrudeOilFeature UNDERGROUND_INSTANCE = new CrudeOilFeature(BlockStateConfiguration.CODEC, false);
+public class SurfaceMattersLakesFeature extends VELakesFeature {
+    public static SurfaceMattersLakesFeature SURFACE_INSTANCE = new SurfaceMattersLakesFeature(BlockStateConfiguration.CODEC, true);
+    public static SurfaceMattersLakesFeature UNDERGROUND_INSTANCE = new SurfaceMattersLakesFeature(BlockStateConfiguration.CODEC, false);
 
     private final boolean isForSurface;
 
-    public CrudeOilFeature(Codec<BlockStateConfiguration> codec, boolean forSurface) {
+    public SurfaceMattersLakesFeature(Codec<BlockStateConfiguration> codec, boolean forSurface) {
         super(codec);
         this.isForSurface = forSurface;
     }

--- a/src/main/java/com/veteam/voluminousenergy/world/feature/SurfaceMattersLakesFeature.java
+++ b/src/main/java/com/veteam/voluminousenergy/world/feature/SurfaceMattersLakesFeature.java
@@ -10,8 +10,6 @@ import net.minecraft.world.level.levelgen.feature.configurations.BlockStateConfi
 import java.util.Random;
 
 public class SurfaceMattersLakesFeature extends VELakesFeature {
-    public static SurfaceMattersLakesFeature SURFACE_INSTANCE = new SurfaceMattersLakesFeature(BlockStateConfiguration.CODEC, true);
-    public static SurfaceMattersLakesFeature UNDERGROUND_INSTANCE = new SurfaceMattersLakesFeature(BlockStateConfiguration.CODEC, false);
 
     private final boolean isForSurface;
 

--- a/src/main/java/com/veteam/voluminousenergy/world/feature/SurfaceMattersLakesFeature.java
+++ b/src/main/java/com/veteam/voluminousenergy/world/feature/SurfaceMattersLakesFeature.java
@@ -28,6 +28,6 @@ public class SurfaceMattersLakesFeature extends VELakesFeature {
 
         if (worldIn.canSeeSky(pos) && this.isForSurface) return super.place(context);
 
-        return !this.isForSurface && super.place(worldIn, generator, rand, new BlockPos(pos.getX(), rand.nextInt(32) + 16, pos.getZ()), conf); // Should place between 32 and 48
+        return !this.isForSurface && super.place(worldIn, generator, rand, new BlockPos(pos.getX(), rand.nextInt(48 + 32) - 32, pos.getZ()), conf); // Should place between -32 and 48
     }
 }

--- a/src/main/java/com/veteam/voluminousenergy/world/feature/VEFeatures.java
+++ b/src/main/java/com/veteam/voluminousenergy/world/feature/VEFeatures.java
@@ -24,14 +24,16 @@ public class VEFeatures { // TODO: Investigate `BlockTags.FEATURES_CANNOT_REPLAC
     /*** Configs and Placements for impls of features ***/
 
     // Oil Lake
-    public static ConfiguredFeature<?,?> OIL_LAKE_FEATURE = new ConfiguredFeature<>(VEFeatures.VE_BSC_LAKE_FEATURE, new BlockStateConfiguration(CrudeOil.CRUDE_OIL.defaultFluidState().createLegacyBlock()));
-    public static PlacedFeature SURFACE_OIL_LAKE_PLACEMENT = new PlacedFeature(Holder.direct(OIL_LAKE_FEATURE), List.of(
+    public static ConfiguredFeature<?,?> SURFACE_OIL_LAKE_FEATURE = new ConfiguredFeature<>(SurfaceMattersLakesFeature.SURFACE_INSTANCE, new BlockStateConfiguration(CrudeOil.CRUDE_OIL.defaultFluidState().createLegacyBlock()));
+    public static PlacedFeature SURFACE_OIL_LAKE_PLACEMENT = new PlacedFeature(Holder.direct(SURFACE_OIL_LAKE_FEATURE), List.of(
             HeightRangePlacement.uniform(VerticalAnchor.bottom(), VerticalAnchor.top()), // TODO: Config
             InSquarePlacement.spread(),
             CountPlacement.of(1),
             RarityFilter.onAverageOnceEvery(Config.SURFACE_OIL_LAKE_CHANCE.get()) // 65 by default
     ));
-    public static PlacedFeature UNDERGROUND_OIL_LAKE_PLACEMENT = new PlacedFeature(Holder.direct(OIL_LAKE_FEATURE), List.of(
+
+    public static ConfiguredFeature<?,?> UNDERGROUND_OIL_LAKE_FEATURE = new ConfiguredFeature<>(SurfaceMattersLakesFeature.UNDERGROUND_INSTANCE, new BlockStateConfiguration(CrudeOil.CRUDE_OIL.defaultFluidState().createLegacyBlock()));
+    public static PlacedFeature UNDERGROUND_OIL_LAKE_PLACEMENT = new PlacedFeature(Holder.direct(UNDERGROUND_OIL_LAKE_FEATURE), List.of(
             HeightRangePlacement.uniform(VerticalAnchor.bottom(), VerticalAnchor.top()), // TODO: Config
             InSquarePlacement.spread(),
             CountPlacement.of(1),

--- a/src/main/java/com/veteam/voluminousenergy/world/feature/VEFeatures.java
+++ b/src/main/java/com/veteam/voluminousenergy/world/feature/VEFeatures.java
@@ -31,7 +31,7 @@ public class VEFeatures { // TODO: Investigate `BlockTags.FEATURES_CANNOT_REPLAC
             HeightRangePlacement.uniform(VerticalAnchor.bottom(), VerticalAnchor.top()), // TODO: Config
             InSquarePlacement.spread(),
             CountPlacement.of(1),
-            RarityFilter.onAverageOnceEvery(Config.SURFACE_OIL_LAKE_CHANCE.get()) // 65 by default
+            RarityFilter.onAverageOnceEvery(Config.SURFACE_OIL_LAKE_CHANCE.get()) // 144 by default
     ));
 
     public static ConfiguredFeature<?,?> UNDERGROUND_OIL_LAKE_FEATURE = new ConfiguredFeature<>(VE_BSC_LAKE_UNDERGROUND_FEATURE, new BlockStateConfiguration(CrudeOil.CRUDE_OIL.defaultFluidState().createLegacyBlock()));
@@ -39,7 +39,7 @@ public class VEFeatures { // TODO: Investigate `BlockTags.FEATURES_CANNOT_REPLAC
             HeightRangePlacement.uniform(VerticalAnchor.bottom(), VerticalAnchor.top()), // TODO: Config
             InSquarePlacement.spread(),
             CountPlacement.of(1),
-            RarityFilter.onAverageOnceEvery(Config.UNDERGROUND_OIL_LAKE_CHANCE.get()) // 15 by default
+            RarityFilter.onAverageOnceEvery(Config.UNDERGROUND_OIL_LAKE_CHANCE.get()) // 5 by default
     ));
 
     // Oil Geyser
@@ -48,7 +48,7 @@ public class VEFeatures { // TODO: Investigate `BlockTags.FEATURES_CANNOT_REPLAC
             HeightRangePlacement.uniform(VerticalAnchor.bottom(), VerticalAnchor.top()), // TODO: Config
             InSquarePlacement.spread(),
             CountPlacement.of(1),
-            RarityFilter.onAverageOnceEvery(Config.OIL_GEYSER_CHANCE.get()) // 100 by default
+            RarityFilter.onAverageOnceEvery(Config.OIL_GEYSER_CHANCE.get()) // 208 by default
     ));
 
     // Rice

--- a/src/main/java/com/veteam/voluminousenergy/world/feature/VEFeatures.java
+++ b/src/main/java/com/veteam/voluminousenergy/world/feature/VEFeatures.java
@@ -20,11 +20,13 @@ public class VEFeatures { // TODO: Investigate `BlockTags.FEATURES_CANNOT_REPLAC
     public static final Feature<BlockStateConfiguration> VE_GEYSER_FEATURE = new GeyserFeature(BlockStateConfiguration.CODEC); // Geyser using BlockStateConfiguration
     public static final Feature<BlockStateConfiguration> VE_RICE_FEATURE = new RiceFeature(BlockStateConfiguration.CODEC); // Rice crop using BlockStateConfiguration
     public static final Feature<VEOreDepositFeature.Configuration> VE_ORE_DEPOSIT_FEATURE = new VEOreDepositFeature(VEOreDepositFeature.Configuration.CODEC);
+    public static final SurfaceMattersLakesFeature VE_BSC_LAKE_SURFACE_FEATURE = new SurfaceMattersLakesFeature(BlockStateConfiguration.CODEC, true);
+    public static final SurfaceMattersLakesFeature VE_BSC_LAKE_UNDERGROUND_FEATURE = new SurfaceMattersLakesFeature(BlockStateConfiguration.CODEC, false);
 
     /*** Configs and Placements for impls of features ***/
 
     // Oil Lake
-    public static ConfiguredFeature<?,?> SURFACE_OIL_LAKE_FEATURE = new ConfiguredFeature<>(SurfaceMattersLakesFeature.SURFACE_INSTANCE, new BlockStateConfiguration(CrudeOil.CRUDE_OIL.defaultFluidState().createLegacyBlock()));
+    public static ConfiguredFeature<?,?> SURFACE_OIL_LAKE_FEATURE = new ConfiguredFeature<>(VE_BSC_LAKE_SURFACE_FEATURE, new BlockStateConfiguration(CrudeOil.CRUDE_OIL.defaultFluidState().createLegacyBlock()));
     public static PlacedFeature SURFACE_OIL_LAKE_PLACEMENT = new PlacedFeature(Holder.direct(SURFACE_OIL_LAKE_FEATURE), List.of(
             HeightRangePlacement.uniform(VerticalAnchor.bottom(), VerticalAnchor.top()), // TODO: Config
             InSquarePlacement.spread(),
@@ -32,7 +34,7 @@ public class VEFeatures { // TODO: Investigate `BlockTags.FEATURES_CANNOT_REPLAC
             RarityFilter.onAverageOnceEvery(Config.SURFACE_OIL_LAKE_CHANCE.get()) // 65 by default
     ));
 
-    public static ConfiguredFeature<?,?> UNDERGROUND_OIL_LAKE_FEATURE = new ConfiguredFeature<>(SurfaceMattersLakesFeature.UNDERGROUND_INSTANCE, new BlockStateConfiguration(CrudeOil.CRUDE_OIL.defaultFluidState().createLegacyBlock()));
+    public static ConfiguredFeature<?,?> UNDERGROUND_OIL_LAKE_FEATURE = new ConfiguredFeature<>(VE_BSC_LAKE_UNDERGROUND_FEATURE, new BlockStateConfiguration(CrudeOil.CRUDE_OIL.defaultFluidState().createLegacyBlock()));
     public static PlacedFeature UNDERGROUND_OIL_LAKE_PLACEMENT = new PlacedFeature(Holder.direct(UNDERGROUND_OIL_LAKE_FEATURE), List.of(
             HeightRangePlacement.uniform(VerticalAnchor.bottom(), VerticalAnchor.top()), // TODO: Config
             InSquarePlacement.spread(),


### PR DESCRIPTION
PR to rebalance Oil Lakes to match generation similar to 1.18.1. Rarer on the surface, but more common underground. Additionally, increase the y-range underground where Oil Lakes can spawn underground, and bump up the chance (to 5 by default) to accommodate for the larger spawn area while maintaining similar density to 1.18.1.

PLEASE NOTE YOU HAVE TO DELETE YOUR CONFIGURATION TOML FILE/EDIT IT TO GET THE NEW DEFAULT CHANCE VALUE!

Example of spawning at Y8:
![2022-03-04_17 03 38](https://user-images.githubusercontent.com/6241870/156849004-3212e1bd-736e-485d-8e40-8ed3ffc68cac.png)

