### PR TITLE
Pull in 1.18.2 Recipe fixes

### DIFF
--- a/src/main/java/com/veteam/voluminousenergy/VoluminousEnergy.java
+++ b/src/main/java/com/veteam/voluminousenergy/VoluminousEnergy.java
@@ -837,6 +837,7 @@ public class VoluminousEnergy {
 
     }
 
+    /*
     @Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD)
     public static class OnDatagenEvent {
 
@@ -848,5 +849,5 @@ public class VoluminousEnergy {
                 dataGenerator.addProvider(new VETagDataGenerator(dataGenerator, event.getExistingFileHelper()));
             }
         }
-    }
+    }*/
 }

--- a/src/main/java/com/veteam/voluminousenergy/blocks/tiles/CentrifugalSeparatorTile.java
+++ b/src/main/java/com/veteam/voluminousenergy/blocks/tiles/CentrifugalSeparatorTile.java
@@ -271,7 +271,7 @@ public class CentrifugalSeparatorTile extends VoluminousTileEntity implements IV
             CentrifugalSeparatorRecipe recipe1 = level.getRecipeManager().getRecipeFor(CentrifugalSeparatorRecipe.RECIPE_TYPE, new SimpleContainer(inputItemStack.get().copy()),level).orElse(null);
 
             if (slot == 0 && recipe != null){
-                for (ItemStack testStack : recipe.ingredient.getItems()){
+                for (ItemStack testStack : recipe.ingredient.get().getItems()){
                     if(stack.getItem() == testStack.getItem()){
                         return true;
                     }
@@ -301,7 +301,7 @@ public class CentrifugalSeparatorTile extends VoluminousTileEntity implements IV
             CentrifugalSeparatorRecipe recipe1 = level.getRecipeManager().getRecipeFor(CentrifugalSeparatorRecipe.RECIPE_TYPE, new SimpleContainer(inputItemStack.get().copy()),level).orElse(null);
 
             if(slot == 0 && recipe != null) {
-                for (ItemStack testStack : recipe.ingredient.getItems()){
+                for (ItemStack testStack : recipe.ingredient.get().getItems()){
                     if(stack.getItem() == testStack.getItem()){
                         return super.insertItem(slot, stack, simulate);
                     }

--- a/src/main/java/com/veteam/voluminousenergy/blocks/tiles/CompressorTile.java
+++ b/src/main/java/com/veteam/voluminousenergy/blocks/tiles/CompressorTile.java
@@ -118,7 +118,7 @@ public class CompressorTile extends VoluminousTileEntity implements IVEPoweredTi
                 CompressorRecipe recipe1 = level.getRecipeManager().getRecipeFor(CompressorRecipe.RECIPE_TYPE, new SimpleContainer(inputItemStack.get().copy()),level).orElse(null);
 
                 if (slot == 0 && recipe != null){
-                    return recipe.ingredient.test(stack);
+                    return recipe.ingredient.get().test(stack);
                 } else if (slot == 1 && recipe1 != null){
                     return stack.getItem() == recipe1.result.getItem();
                 } else if (slot == 2){
@@ -136,7 +136,7 @@ public class CompressorTile extends VoluminousTileEntity implements IVEPoweredTi
                 CompressorRecipe recipe1 = level.getRecipeManager().getRecipeFor(CompressorRecipe.RECIPE_TYPE, new SimpleContainer(inputItemStack.get().copy()),level).orElse(null);
 
                 if(slot == 0 && recipe != null) {
-                    for (ItemStack testStack : recipe.ingredient.getItems()){
+                    for (ItemStack testStack : recipe.ingredient.get().getItems()){
                         if(stack.getItem() == testStack.getItem()){
                             return super.insertItem(slot, stack, simulate);
                         }

--- a/src/main/java/com/veteam/voluminousenergy/blocks/tiles/CrusherTile.java
+++ b/src/main/java/com/veteam/voluminousenergy/blocks/tiles/CrusherTile.java
@@ -69,7 +69,7 @@ public class CrusherTile extends VoluminousTileEntity implements IVEPoweredTileE
             CrusherRecipe recipe1 = level.getRecipeManager().getRecipeFor(CrusherRecipe.RECIPE_TYPE, new SimpleContainer(inputItemStack.get().copy()),level).orElse(null);
 
             if (slot == 0 && recipe != null){
-                return recipe.ingredient.test(stack);
+                return recipe.ingredient.get().test(stack);
             } else if (slot == 1 && recipe1 != null){
                 return stack.getItem() == recipe1.result.getItem();
             } else if (slot == 2 && recipe1 != null){
@@ -89,7 +89,7 @@ public class CrusherTile extends VoluminousTileEntity implements IVEPoweredTileE
             CrusherRecipe recipe1 = level.getRecipeManager().getRecipeFor(CrusherRecipe.RECIPE_TYPE, new SimpleContainer(inputItemStack.get().copy()),level).orElse(null);
 
             if(slot == 0 && recipe != null) {
-                for (ItemStack testStack : recipe.ingredient.getItems()){
+                for (ItemStack testStack : recipe.ingredient.get().getItems()){
                     if(stack.getItem() == testStack.getItem()){
                         return super.insertItem(slot, stack, simulate);
                     }

--- a/src/main/java/com/veteam/voluminousenergy/blocks/tiles/ElectrolyzerTile.java
+++ b/src/main/java/com/veteam/voluminousenergy/blocks/tiles/ElectrolyzerTile.java
@@ -277,7 +277,7 @@ public class ElectrolyzerTile extends VoluminousTileEntity implements IVEPowered
             ElectrolyzerRecipe recipe1 = level.getRecipeManager().getRecipeFor(ElectrolyzerRecipe.RECIPE_TYPE, new SimpleContainer(inputItemStack.get().copy()),level).orElse(null);
 
             if (slot == 0 && recipe != null){
-                for (ItemStack testStack : recipe.ingredient.getItems()){
+                for (ItemStack testStack : recipe.ingredient.get().getItems()){
                     if(stack.getItem() == testStack.getItem()){
                         return true;
                     }
@@ -307,7 +307,7 @@ public class ElectrolyzerTile extends VoluminousTileEntity implements IVEPowered
             ElectrolyzerRecipe recipe1 = level.getRecipeManager().getRecipeFor(ElectrolyzerRecipe.RECIPE_TYPE, new SimpleContainer(inputItemStack.get().copy()),level).orElse(null);
 
             if(slot == 0 && recipe != null) {
-                for (ItemStack testStack : recipe.ingredient.getItems()){
+                for (ItemStack testStack : recipe.ingredient.get().getItems()){
                     if(stack.getItem() == testStack.getItem()){
                         return super.insertItem(slot, stack, simulate);
                     }

--- a/src/main/java/com/veteam/voluminousenergy/blocks/tiles/ImplosionCompressorTile.java
+++ b/src/main/java/com/veteam/voluminousenergy/blocks/tiles/ImplosionCompressorTile.java
@@ -124,7 +124,7 @@ public class ImplosionCompressorTile extends VoluminousTileEntity implements IVE
                 ImplosionCompressorRecipe recipe1 = level.getRecipeManager().getRecipeFor(ImplosionCompressorRecipe.RECIPE_TYPE, new SimpleContainer(inputItemStack.get().copy()),level).orElse(null);
 
                 if (slot == 0 && recipe != null){
-                    return recipe.ingredient.test(stack);
+                    return recipe.ingredient.get().test(stack);
                 } else if (slot == 1) {
                     return stack.getItem() == Items.GUNPOWDER;
                 } else if (slot == 2 && recipe1 != null){
@@ -144,7 +144,7 @@ public class ImplosionCompressorTile extends VoluminousTileEntity implements IVE
                 ImplosionCompressorRecipe recipe1 = level.getRecipeManager().getRecipeFor(ImplosionCompressorRecipe.RECIPE_TYPE, new SimpleContainer(inputItemStack.get().copy()),level).orElse(null);
 
                 if(slot == 0 && recipe != null) {
-                    for (ItemStack testStack : recipe.ingredient.getItems()) {
+                    for (ItemStack testStack : recipe.ingredient.get().getItems()) {
                         if (stack.getItem() == testStack.getItem()) {
                             return super.insertItem(slot, stack, simulate);
                         }

--- a/src/main/java/com/veteam/voluminousenergy/blocks/tiles/PrimitiveStirlingGeneratorTile.java
+++ b/src/main/java/com/veteam/voluminousenergy/blocks/tiles/PrimitiveStirlingGeneratorTile.java
@@ -109,7 +109,7 @@ public class PrimitiveStirlingGeneratorTile extends VoluminousTileEntity impleme
                 ItemStack referenceStack = stack.copy();
                 referenceStack.setCount(64);
                 StirlingGeneratorRecipe recipe = RecipeUtil.getStirlingGeneratorRecipe(level, stack);
-                return slot == 0 && recipe != null && recipe.ingredient.test(referenceStack);
+                return slot == 0 && recipe != null && recipe.getIngredient().test(referenceStack);
             }
 
             @Nonnull
@@ -118,7 +118,7 @@ public class PrimitiveStirlingGeneratorTile extends VoluminousTileEntity impleme
                 StirlingGeneratorRecipe recipe = RecipeUtil.getStirlingGeneratorRecipe(level, stack);
 
                 if(slot == 0 && recipe != null) {
-                    for (ItemStack testStack : recipe.ingredient.getItems()){
+                    for (ItemStack testStack : recipe.getIngredient().getItems()){
                         if(stack.getItem() == testStack.getItem()){
                             return super.insertItem(slot, stack, simulate);
                         }

--- a/src/main/java/com/veteam/voluminousenergy/blocks/tiles/StirlingGeneratorTile.java
+++ b/src/main/java/com/veteam/voluminousenergy/blocks/tiles/StirlingGeneratorTile.java
@@ -134,7 +134,7 @@ public class StirlingGeneratorTile extends VoluminousTileEntity implements IVEPo
                 ItemStack referenceStack = stack.copy();
                 referenceStack.setCount(64);
                 StirlingGeneratorRecipe recipe = RecipeUtil.getStirlingGeneratorRecipe(level, stack);
-                return slot == 0 && recipe != null && recipe.ingredient.test(referenceStack);
+                return slot == 0 && recipe != null && recipe.getIngredient().test(referenceStack);
             }
 
             @Nonnull
@@ -143,7 +143,7 @@ public class StirlingGeneratorTile extends VoluminousTileEntity implements IVEPo
                 StirlingGeneratorRecipe recipe = RecipeUtil.getStirlingGeneratorRecipe(level, stack);
 
                 if(slot == 0 && recipe != null) {
-                    for (ItemStack testStack : recipe.ingredient.getItems()){
+                    for (ItemStack testStack : recipe.getIngredient().getItems()){
                         if(stack.getItem() == testStack.getItem()){
                             return super.insertItem(slot, stack, simulate);
                         }

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/CombustionCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/CombustionCategory.java
@@ -91,7 +91,7 @@ public class CombustionCategory implements IRecipeCategory<CombustionGeneratorFu
                         j = orderOxidizers(i+1,j);
                         slotDrawable.draw(matrixStack,2 + j, 45);
                         int fePerTick = recipe.getVolumetricEnergy()/CombustionGeneratorOxidizerRecipe.oxidizerRecipes.get(i).getProcessTime();
-                        Minecraft.getInstance().font.draw(matrixStack,fePerTick+"",4+j,64,0x606060);
+                        Minecraft.getInstance().font.draw(matrixStack,fePerTick+"",3+j,64,0x606060);
                     }
 
                 } else { // Assume empty
@@ -101,7 +101,7 @@ public class CombustionCategory implements IRecipeCategory<CombustionGeneratorFu
                     j = orderOxidizers(i+1,j);
                     slotDrawable.draw(matrixStack,2 + j, 45);
                     int fePerTick = recipe.getVolumetricEnergy()/CombustionGeneratorOxidizerRecipe.oxidizerRecipes.get(i).getProcessTime();
-                    Minecraft.getInstance().font.draw(matrixStack,fePerTick+"",4+j,64,0x606060);
+                    Minecraft.getInstance().font.draw(matrixStack,fePerTick+"",3+j,64,0x606060);
                 }
             }
         }
@@ -165,15 +165,12 @@ public class CombustionCategory implements IRecipeCategory<CombustionGeneratorFu
         fluidStacks.set(0, recipe.fluidInputList);
     }
 
-    public int orderOxidizers(int i, int j){
-        if(i > 1){
-            switch (i) {
-                case 2:
-                    return j + i * 12;
-                default:
-                    return 2*j;
-            }
-        }
-        return j;
+    @Deprecated
+    public int orderOxidizers(int i, int j){ // TODO: Switch to j-only, verify after forge fix
+        return j == 0 ? 1 : j+24;
+    }
+
+    public int orderOxidizers(int j){
+        return j == 0 ? 1 : j+24;
     }
 }

--- a/src/main/java/com/veteam/voluminousenergy/recipe/AqueoulizerRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/AqueoulizerRecipe.java
@@ -18,6 +18,7 @@ import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.material.Fluid;
+import net.minecraftforge.common.util.Lazy;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.ForgeRegistryEntry;
@@ -54,7 +55,7 @@ public class AqueoulizerRecipe extends VEFluidRecipe {
     }
 
     @Override
-    public Ingredient getIngredient(){ return ingredient;}
+    public Ingredient getIngredient(){ return ingredient.get();}
 
     @Override
     public int getIngredientCount(){ return ingredientCount;}
@@ -82,7 +83,7 @@ public class AqueoulizerRecipe extends VEFluidRecipe {
     public boolean matches(Container inv, Level worldIn){
         ItemStack stack = inv.getItem(0);
         int count = stack.getCount();
-        return ingredient.test(stack) && count >= ingredientCount;
+        return ingredient.get().test(stack) && count >= ingredientCount;
     }
 
     @Override
@@ -146,12 +147,12 @@ public class AqueoulizerRecipe extends VEFluidRecipe {
         public AqueoulizerRecipe fromJson(ResourceLocation recipeId, JsonObject json) {
             AqueoulizerRecipe recipe = new AqueoulizerRecipe(recipeId);
 
-            recipe.ingredient = Ingredient.fromJson(json.get("ingredient"));
+            recipe.ingredient = Lazy.of(() -> Ingredient.fromJson(json.get("ingredient")));
             recipe.ingredientCount = GsonHelper.getAsInt(json.get("ingredient").getAsJsonObject(), "count", 1);
             recipe.processTime = GsonHelper.getAsInt(json,"process_time",200);
 
 
-            for (ItemStack stack : recipe.ingredient.getItems()){
+            for (ItemStack stack : recipe.ingredient.get().getItems()){
                 if(!recipe.ingredientList.contains(stack.getItem())){
                     recipe.ingredientList.add(stack.getItem());
                 }
@@ -198,7 +199,7 @@ public class AqueoulizerRecipe extends VEFluidRecipe {
         @Override
         public AqueoulizerRecipe fromNetwork(ResourceLocation recipeId, FriendlyByteBuf buffer){
             AqueoulizerRecipe recipe = new AqueoulizerRecipe((recipeId));
-            recipe.ingredient = Ingredient.fromNetwork(buffer);
+            recipe.ingredient = Lazy.of(() -> Ingredient.fromNetwork(buffer));
             recipe.ingredientCount = buffer.readByte();
             recipe.result = buffer.readFluidStack();
 
@@ -218,7 +219,7 @@ public class AqueoulizerRecipe extends VEFluidRecipe {
 
         @Override
         public void toNetwork(FriendlyByteBuf buffer, AqueoulizerRecipe recipe){
-            recipe.ingredient.toNetwork(buffer);
+            recipe.ingredient.get().toNetwork(buffer);
             buffer.writeByte(recipe.getIngredientCount());
             buffer.writeFluidStack(recipe.result);
 

--- a/src/main/java/com/veteam/voluminousenergy/recipe/CentrifugalAgitatorRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/CentrifugalAgitatorRecipe.java
@@ -18,6 +18,7 @@ import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.material.Fluid;
+import net.minecraftforge.common.util.Lazy;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.ForgeRegistryEntry;
@@ -61,7 +62,7 @@ public class CentrifugalAgitatorRecipe extends VEFluidRecipe {
     }
 
     @Override
-    public Ingredient getIngredient(){ return ingredient; }
+    public Ingredient getIngredient(){ return ingredient.get(); }
 
     @Override
     public int getIngredientCount(){ return ingredientCount;}
@@ -113,7 +114,7 @@ public class CentrifugalAgitatorRecipe extends VEFluidRecipe {
     public boolean matches(Container inv, Level worldIn){
         ItemStack stack = inv.getItem(0);
         int count = stack.getCount();
-        return ingredient.test(stack) && count >= ingredientCount;
+        return ingredient.get().test(stack) && count >= ingredientCount;
     }
 
     @Override
@@ -156,7 +157,7 @@ public class CentrifugalAgitatorRecipe extends VEFluidRecipe {
         public CentrifugalAgitatorRecipe fromJson(ResourceLocation recipeId, JsonObject json) {
             CentrifugalAgitatorRecipe recipe = new CentrifugalAgitatorRecipe(recipeId);
 
-            recipe.ingredient = Ingredient.fromJson(json.get("ingredient"));
+            recipe.ingredient = Lazy.of(() -> Ingredient.fromJson(json.get("ingredient")));
             recipe.ingredientCount = GsonHelper.getAsInt(json.get("ingredient").getAsJsonObject(), "count", 1);
 
             recipe.processTime = GsonHelper.getAsInt(json,"process_time",200);
@@ -207,7 +208,7 @@ public class CentrifugalAgitatorRecipe extends VEFluidRecipe {
         @Override
         public CentrifugalAgitatorRecipe fromNetwork(ResourceLocation recipeId, FriendlyByteBuf buffer){
             CentrifugalAgitatorRecipe recipe = new CentrifugalAgitatorRecipe((recipeId));
-            recipe.ingredient = Ingredient.fromNetwork(buffer);
+            recipe.ingredient = Lazy.of(() -> Ingredient.fromNetwork(buffer));
             recipe.ingredientCount = buffer.readByte();
 
             // This is probably not great, but eh, what else am I supposed to do in this situation?
@@ -229,7 +230,7 @@ public class CentrifugalAgitatorRecipe extends VEFluidRecipe {
 
         @Override
         public void toNetwork(FriendlyByteBuf buffer, CentrifugalAgitatorRecipe recipe){
-            recipe.ingredient.toNetwork(buffer);
+            recipe.ingredient.get().toNetwork(buffer);
             buffer.writeByte(recipe.getIngredientCount());
 
             buffer.writeInt(recipe.inputArraySize);

--- a/src/main/java/com/veteam/voluminousenergy/recipe/CentrifugalSeparatorRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/CentrifugalSeparatorRecipe.java
@@ -13,6 +13,7 @@ import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.util.Lazy;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.ForgeRegistryEntry;
 
@@ -28,7 +29,7 @@ public class CentrifugalSeparatorRecipe extends VERecipe{
     public static final CentrifugalSeparatorRecipe.Serializer SERIALIZER = new CentrifugalSeparatorRecipe.Serializer();
 
     public final ResourceLocation recipeId;
-    public Ingredient ingredient;
+    public Lazy<Ingredient> ingredient;
     public int ingredientCount;
     public ItemStack result;
     private ItemStack rngResult0;
@@ -50,7 +51,7 @@ public class CentrifugalSeparatorRecipe extends VERecipe{
         this.recipeId = recipeId;
     }
 
-    public Ingredient getIngredient(){ return ingredient;}
+    public Ingredient getIngredient(){ return ingredient.get();}
 
     public int getIngredientCount(){ return ingredientCount;}
 
@@ -72,7 +73,7 @@ public class CentrifugalSeparatorRecipe extends VERecipe{
     public boolean matches(Container inv, Level worldIn){
         ItemStack stack = inv.getItem(0);
         int count = stack.getCount();
-        return ingredient.test(stack) && count >= ingredientCount;
+        return ingredient.get().test(stack) && count >= ingredientCount;
     }
 
     @Override
@@ -122,11 +123,11 @@ public class CentrifugalSeparatorRecipe extends VERecipe{
         public CentrifugalSeparatorRecipe fromJson(ResourceLocation recipeId, JsonObject json){
             CentrifugalSeparatorRecipe recipe = new CentrifugalSeparatorRecipe(recipeId);
 
-            recipe.ingredient = Ingredient.fromJson(json.get("ingredient"));
+            recipe.ingredient = Lazy.of(() -> Ingredient.fromJson(json.get("ingredient")));
             recipe.ingredientCount = GsonHelper.getAsInt(json.get("ingredient").getAsJsonObject(), "count", 1);
             recipe.processTime = GsonHelper.getAsInt(json,"process_time",200);
 
-            for (ItemStack stack : recipe.ingredient.getItems()){
+            for (ItemStack stack : recipe.ingredient.get().getItems()){
                 if(!ingredientList.contains(stack.getItem())){
                     ingredientList.add(stack.getItem());
                 }
@@ -174,7 +175,7 @@ public class CentrifugalSeparatorRecipe extends VERecipe{
         @Override
         public CentrifugalSeparatorRecipe fromNetwork(ResourceLocation recipeId, FriendlyByteBuf buffer){
             CentrifugalSeparatorRecipe recipe = new CentrifugalSeparatorRecipe(recipeId);
-            recipe.ingredient = Ingredient.fromNetwork(buffer);
+            recipe.ingredient = Lazy.of(() -> Ingredient.fromNetwork(buffer));
             recipe.ingredientCount = buffer.readByte();
             recipe.result = buffer.readItem();
             recipe.processTime = buffer.readInt();
@@ -197,7 +198,7 @@ public class CentrifugalSeparatorRecipe extends VERecipe{
 
         @Override
         public void toNetwork(FriendlyByteBuf buffer, CentrifugalSeparatorRecipe recipe){
-            recipe.ingredient.toNetwork(buffer);
+            recipe.ingredient.get().toNetwork(buffer);
             buffer.writeByte(recipe.getIngredientCount());
             buffer.writeItem(recipe.getResult());
             buffer.writeInt(recipe.processTime);

--- a/src/main/java/com/veteam/voluminousenergy/recipe/CombustionGenerator/CombustionGeneratorFuelRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/CombustionGenerator/CombustionGeneratorFuelRecipe.java
@@ -22,6 +22,7 @@ import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.material.Fluid;
+import net.minecraftforge.common.util.Lazy;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.ForgeRegistryEntry;
@@ -61,7 +62,7 @@ public class CombustionGeneratorFuelRecipe extends VEFluidRecipe {
         return ImmutableMap.copyOf(ingredients);
     }
 
-    public Ingredient getIngredient(){ return ingredient;}
+    public Ingredient getIngredient(){ return ingredient.get();}
 
     public int getIngredientCount(){ return ingredientCount;}
 
@@ -75,7 +76,7 @@ public class CombustionGeneratorFuelRecipe extends VEFluidRecipe {
     public boolean matches(Container inv, Level worldIn){
         ItemStack stack = inv.getItem(0);
         int count = stack.getCount();
-        return ingredient.test(stack) && count >= ingredientCount;
+        return ingredient.get().test(stack) && count >= ingredientCount;
     }
 
     @Override
@@ -155,11 +156,11 @@ public class CombustionGeneratorFuelRecipe extends VEFluidRecipe {
         public CombustionGeneratorFuelRecipe fromJson(ResourceLocation recipeId, JsonObject json) {
             CombustionGeneratorFuelRecipe recipe = new CombustionGeneratorFuelRecipe(recipeId);
 
-            recipe.ingredient = Ingredient.fromJson(json.get("ingredient"));
+            recipe.ingredient = Lazy.of(() -> Ingredient.fromJson(json.get("ingredient")));
             recipe.ingredientCount = GsonHelper.getAsInt(json.get("ingredient").getAsJsonObject(), "count", 1);
             recipe.volumetricEnergy = GsonHelper.getAsInt(json.get("ingredient").getAsJsonObject(), "volumetric_energy", 102400);
 
-            for (ItemStack stack : recipe.ingredient.getItems()){
+            for (ItemStack stack : recipe.ingredient.get().getItems()){
                 if(!recipe.ingredientList.contains(stack.getItem())){
                     recipe.ingredientList.add(stack.getItem());
                 }
@@ -206,7 +207,7 @@ public class CombustionGeneratorFuelRecipe extends VEFluidRecipe {
         @Override
         public CombustionGeneratorFuelRecipe fromNetwork(ResourceLocation recipeId, FriendlyByteBuf buffer){
             CombustionGeneratorFuelRecipe recipe = new CombustionGeneratorFuelRecipe((recipeId));
-            recipe.ingredient = Ingredient.fromNetwork(buffer);
+            recipe.ingredient = Lazy.of(() -> Ingredient.fromNetwork(buffer));
             recipe.ingredientCount = buffer.readByte();
             recipe.volumetricEnergy = buffer.readInt();
 
@@ -228,7 +229,7 @@ public class CombustionGeneratorFuelRecipe extends VEFluidRecipe {
 
         @Override
         public void toNetwork(FriendlyByteBuf buffer, CombustionGeneratorFuelRecipe recipe){
-            recipe.ingredient.toNetwork(buffer);
+            recipe.ingredient.get().toNetwork(buffer);
             buffer.writeByte(recipe.getIngredientCount());
             buffer.writeInt(recipe.volumetricEnergy);
 

--- a/src/main/java/com/veteam/voluminousenergy/recipe/CombustionGenerator/CombustionGeneratorOxidizerRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/CombustionGenerator/CombustionGeneratorOxidizerRecipe.java
@@ -147,8 +147,9 @@ public class CombustionGeneratorOxidizerRecipe extends VERecipe {
                         recipe.nsRawFluidInputList.add(tempStack.getRawFluid());
                         recipe.inputArraySize = recipe.nsFluidInputList.size();
                     }
+                    oxidizerRecipes.add(recipe);
                     // Sane add
-                    saneAdd(recipe);
+                    //saneAdd(recipe);
                 } else {
                     VoluminousEnergy.LOGGER.debug("Tag is null!");
                 }
@@ -161,7 +162,8 @@ public class CombustionGeneratorOxidizerRecipe extends VERecipe {
                 recipe.nsFluidInputList.add(recipe.inputFluid.copy());
                 recipe.nsRawFluidInputList.add(recipe.inputFluid.getRawFluid());
                 recipe.inputArraySize = recipe.nsFluidInputList.size();
-                saneAdd(recipe);
+                oxidizerRecipes.add(recipe);
+                //saneAdd(recipe);
             } else {
                 throw new JsonSyntaxException("Bad syntax for the Combustion Fuel recipe, input_fluid must be tag or fluid");
             }
@@ -186,7 +188,8 @@ public class CombustionGeneratorOxidizerRecipe extends VERecipe {
 
             recipe.result = buffer.readItem();
             recipe.processTime = buffer.readInt();
-            saneAdd(recipe);
+            //saneAdd(recipe);
+            oxidizerRecipes.add(recipe);
             return recipe;
         }
 
@@ -202,9 +205,11 @@ public class CombustionGeneratorOxidizerRecipe extends VERecipe {
 
             buffer.writeItem(recipe.getResult());
             buffer.writeInt(recipe.processTime);
-            saneAdd(recipe);
+            oxidizerRecipes.add(recipe);
+            //saneAdd(recipe);
         }
 
+        // TODO: Rewrite after forge fix
         public void saneAdd(CombustionGeneratorOxidizerRecipe recipe){
             if(CombustionGeneratorOxidizerRecipe.oxidizerRecipes.size() >= (Short.MAX_VALUE * 32)) return; // If greater than 1,048,544 don't bother to add any more
             // Sanity check to prevent multiple of the same recipes being stored in the array

--- a/src/main/java/com/veteam/voluminousenergy/recipe/CompressorRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/CompressorRecipe.java
@@ -13,6 +13,7 @@ import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.util.Lazy;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.ForgeRegistryEntry;
 
@@ -27,7 +28,7 @@ public class CompressorRecipe extends VERecipe {
     public static final Serializer SERIALIZER = new Serializer();
 
     public final ResourceLocation recipeId;
-    public Ingredient ingredient;
+    public Lazy<Ingredient> ingredient;
     public int ingredientCount;
     public ItemStack result;
     private int processTime;
@@ -43,7 +44,7 @@ public class CompressorRecipe extends VERecipe {
 
     @Override
     public Ingredient getIngredient() {
-        return ingredient;
+        return ingredient.get();
     }
 
     public int getIngredientCount() {
@@ -59,7 +60,7 @@ public class CompressorRecipe extends VERecipe {
     public boolean matches(Container inv, Level worldIn){
         ItemStack stack = inv.getItem(0);
         int count = stack.getCount();
-        return ingredient.test(stack) && count >= ingredientCount;
+        return ingredient.get().test(stack) && count >= ingredientCount;
     }
 
     @Override
@@ -110,11 +111,11 @@ public class CompressorRecipe extends VERecipe {
 
             CompressorRecipe recipe = new CompressorRecipe(recipeId);
 
-            recipe.ingredient = Ingredient.fromJson(json.get("ingredient"));
+            recipe.ingredient = Lazy.of(() -> Ingredient.fromJson(json.get("ingredient")));
             recipe.ingredientCount = GsonHelper.getAsInt(json.get("ingredient").getAsJsonObject(),"count",1);
             recipe.processTime = GsonHelper.getAsInt(json, "process_time", 200);
 
-            for (ItemStack stack : recipe.ingredient.getItems()){
+            for (ItemStack stack : recipe.ingredient.get().getItems()){
                 if (!ingredientList.contains(stack.getItem())){
                     ingredientList.add(stack.getItem());
                 }
@@ -132,7 +133,7 @@ public class CompressorRecipe extends VERecipe {
         @Override
         public CompressorRecipe fromNetwork(ResourceLocation recipeId, FriendlyByteBuf buffer){
             CompressorRecipe recipe = new CompressorRecipe(recipeId);
-            recipe.ingredient = Ingredient.fromNetwork(buffer);
+            recipe.ingredient = Lazy.of(() -> Ingredient.fromNetwork(buffer));
             recipe.ingredientCount = buffer.readByte();
             recipe.result = buffer.readItem();
             recipe.processTime = buffer.readInt();
@@ -142,7 +143,7 @@ public class CompressorRecipe extends VERecipe {
 
         @Override
         public void toNetwork(FriendlyByteBuf buffer, CompressorRecipe recipe){
-            recipe.ingredient.toNetwork(buffer);
+            recipe.ingredient.get().toNetwork(buffer);
             buffer.writeByte(recipe.getIngredientCount());
             buffer.writeItem(recipe.getResult());
             buffer.writeInt(recipe.processTime);

--- a/src/main/java/com/veteam/voluminousenergy/recipe/CrusherRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/CrusherRecipe.java
@@ -13,6 +13,7 @@ import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.util.Lazy;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.ForgeRegistryEntry;
 
@@ -28,7 +29,7 @@ public class CrusherRecipe extends VERecipe {
     public static final Serializer SERIALIZER = new Serializer();
 
     public final ResourceLocation recipeId;
-    public Ingredient ingredient;
+    public Lazy<Ingredient> ingredient;
     public int ingredientCount;
     public ItemStack result;
     public ItemStack rngResult;
@@ -44,7 +45,7 @@ public class CrusherRecipe extends VERecipe {
         this.recipeId = recipeId;
     }
 
-    public Ingredient getIngredient(){ return ingredient;}
+    public Ingredient getIngredient(){ return ingredient.get();}
 
     public int getIngredientCount(){ return ingredientCount;}
 
@@ -58,7 +59,7 @@ public class CrusherRecipe extends VERecipe {
     public boolean matches(Container inv, Level worldIn){
         ItemStack stack = inv.getItem(0);
         int count = stack.getCount();
-        return ingredient.test(stack) && count >= ingredientCount;
+        return ingredient.get().test(stack) && count >= ingredientCount;
     }
 
     @Override
@@ -102,11 +103,11 @@ public class CrusherRecipe extends VERecipe {
         public CrusherRecipe fromJson(ResourceLocation recipeId, JsonObject json){
             CrusherRecipe recipe = new CrusherRecipe(recipeId);
 
-            recipe.ingredient = Ingredient.fromJson(json.get("ingredient"));
+            recipe.ingredient = Lazy.of(() -> Ingredient.fromJson(json.get("ingredient")));
             recipe.ingredientCount = GsonHelper.getAsInt(json.get("ingredient").getAsJsonObject(), "count", 1);
             recipe.processTime = GsonHelper.getAsInt(json,"process_time",200);
 
-            for (ItemStack stack : recipe.ingredient.getItems()){
+            for (ItemStack stack : recipe.ingredient.get().getItems()){
                 if(!ingredientList.contains(stack.getItem())){
                     ingredientList.add(stack.getItem());
                 }
@@ -132,7 +133,7 @@ public class CrusherRecipe extends VERecipe {
         @Override
         public CrusherRecipe fromNetwork(ResourceLocation recipeId, FriendlyByteBuf buffer){
             CrusherRecipe recipe = new CrusherRecipe((recipeId));
-            recipe.ingredient = Ingredient.fromNetwork(buffer);
+            recipe.ingredient = Lazy.of(() -> Ingredient.fromNetwork(buffer));
             recipe.ingredientCount = buffer.readByte();
             recipe.result = buffer.readItem();
             recipe.processTime = buffer.readInt();
@@ -145,7 +146,7 @@ public class CrusherRecipe extends VERecipe {
 
         @Override
         public void toNetwork(FriendlyByteBuf buffer, CrusherRecipe recipe){
-            recipe.ingredient.toNetwork(buffer);
+            recipe.ingredient.get().toNetwork(buffer);
             buffer.writeByte(recipe.getIngredientCount());
             buffer.writeItem(recipe.getResult());
             buffer.writeInt(recipe.processTime);

--- a/src/main/java/com/veteam/voluminousenergy/recipe/DistillationRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/DistillationRecipe.java
@@ -18,6 +18,7 @@ import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.material.Fluid;
+import net.minecraftforge.common.util.Lazy;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.ForgeRegistryEntry;
@@ -58,7 +59,7 @@ public class DistillationRecipe extends VEFluidRecipe {
     }
 
     @Override
-    public Ingredient getIngredient(){ return ingredient;}
+    public Ingredient getIngredient(){ return ingredient.get();}
 
     @Override
     public int getIngredientCount(){ return ingredientCount;}
@@ -101,7 +102,7 @@ public class DistillationRecipe extends VEFluidRecipe {
     public boolean matches(Container inv, Level worldIn){
         ItemStack stack = inv.getItem(0);
         int count = stack.getCount();
-        return ingredient.test(stack) && count >= ingredientCount;
+        return ingredient.get().test(stack) && count >= ingredientCount;
     }
 
     @Override
@@ -173,12 +174,12 @@ public class DistillationRecipe extends VEFluidRecipe {
         public DistillationRecipe fromJson(ResourceLocation recipeId, JsonObject json) {
             DistillationRecipe recipe = new DistillationRecipe(recipeId);
 
-            recipe.ingredient = Ingredient.fromJson(json.get("ingredient"));
+            recipe.ingredient = Lazy.of(() -> Ingredient.fromJson(json.get("ingredient")));
             recipe.ingredientCount = GsonHelper.getAsInt(json.get("ingredient").getAsJsonObject(), "count", 1);
             recipe.inputAmount = GsonHelper.getAsInt(json.get("ingredient").getAsJsonObject(), "amount", 0);
             recipe.processTime = GsonHelper.getAsInt(json,"process_time",200);
 
-            for (ItemStack stack : recipe.ingredient.getItems()){
+            for (ItemStack stack : recipe.ingredient.get().getItems()){
                 if(!recipe.ingredientList.contains(stack.getItem())){
                     recipe.ingredientList.add(stack.getItem());
                 }
@@ -236,7 +237,7 @@ public class DistillationRecipe extends VEFluidRecipe {
         @Override
         public DistillationRecipe fromNetwork(ResourceLocation recipeId, FriendlyByteBuf buffer){
             DistillationRecipe recipe = new DistillationRecipe((recipeId));
-            recipe.ingredient = Ingredient.fromNetwork(buffer);
+            recipe.ingredient = Lazy.of(() -> Ingredient.fromNetwork(buffer));
             recipe.ingredientCount = buffer.readByte();
             recipe.result = buffer.readFluidStack();
 
@@ -259,7 +260,7 @@ public class DistillationRecipe extends VEFluidRecipe {
 
         @Override
         public void toNetwork(FriendlyByteBuf buffer, DistillationRecipe recipe){
-            recipe.ingredient.toNetwork(buffer);
+            recipe.ingredient.get().toNetwork(buffer);
             buffer.writeByte(recipe.getIngredientCount());
             buffer.writeFluidStack(recipe.result);
 

--- a/src/main/java/com/veteam/voluminousenergy/recipe/ImplosionCompressorRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/ImplosionCompressorRecipe.java
@@ -13,6 +13,7 @@ import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.util.Lazy;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.ForgeRegistryEntry;
 
@@ -27,7 +28,7 @@ public class ImplosionCompressorRecipe extends VERecipe {
     public static final Serializer SERIALIZER = new ImplosionCompressorRecipe.Serializer();
 
     public final ResourceLocation recipeId;
-    public Ingredient ingredient;
+    public Lazy<Ingredient> ingredient;
     public int ingredientCount;
     public ItemStack result;
     private int processTime;
@@ -43,7 +44,7 @@ public class ImplosionCompressorRecipe extends VERecipe {
 
     @Override
     public Ingredient getIngredient() {
-        return ingredient;
+        return ingredient.get();
     }
 
     public int getIngredientCount() {
@@ -59,7 +60,7 @@ public class ImplosionCompressorRecipe extends VERecipe {
     public boolean matches(Container inv, Level worldIn){
         ItemStack stack = inv.getItem(0);
         int count = stack.getCount();
-        return ingredient.test(stack) && count >= ingredientCount;
+        return ingredient.get().test(stack) && count >= ingredientCount;
     }
 
     @Override
@@ -110,11 +111,11 @@ public class ImplosionCompressorRecipe extends VERecipe {
 
             ImplosionCompressorRecipe recipe = new ImplosionCompressorRecipe(recipeId);
 
-            recipe.ingredient = Ingredient.fromJson(json.get("ingredient"));
+            recipe.ingredient = Lazy.of(() -> Ingredient.fromJson(json.get("ingredient")));
             recipe.ingredientCount = GsonHelper.getAsInt(json.get("ingredient").getAsJsonObject(),"count",1);
             recipe.processTime = GsonHelper.getAsInt(json, "process_time", 200);
 
-            for (ItemStack stack : recipe.ingredient.getItems()){
+            for (ItemStack stack : recipe.ingredient.get().getItems()){
                 if (!ingredientList.contains(stack.getItem())){
                     ingredientList.add(stack.getItem());
                 }
@@ -132,7 +133,7 @@ public class ImplosionCompressorRecipe extends VERecipe {
         @Override
         public ImplosionCompressorRecipe fromNetwork(ResourceLocation recipeId, FriendlyByteBuf buffer){
             ImplosionCompressorRecipe recipe = new ImplosionCompressorRecipe(recipeId);
-            recipe.ingredient = Ingredient.fromNetwork(buffer);
+            recipe.ingredient = Lazy.of(() -> Ingredient.fromNetwork(buffer));
             recipe.ingredientCount = buffer.readByte();
             recipe.result = buffer.readItem();
             recipe.processTime = buffer.readInt();
@@ -142,7 +143,7 @@ public class ImplosionCompressorRecipe extends VERecipe {
 
         @Override
         public void toNetwork(FriendlyByteBuf buffer, ImplosionCompressorRecipe recipe){
-            recipe.ingredient.toNetwork(buffer);
+            recipe.ingredient.get().toNetwork(buffer);
             buffer.writeByte(recipe.getIngredientCount());
             buffer.writeItem(recipe.getResult());
             buffer.writeInt(recipe.processTime);

--- a/src/main/java/com/veteam/voluminousenergy/recipe/StirlingGeneratorRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/StirlingGeneratorRecipe.java
@@ -15,6 +15,7 @@ import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.util.Lazy;
 import net.minecraftforge.registries.ForgeRegistryEntry;
 
 import javax.annotation.Nullable;
@@ -28,7 +29,7 @@ public class StirlingGeneratorRecipe extends VERecipe {
     public static final Serializer SERIALIZER = new Serializer();
 
     public final ResourceLocation recipeId;
-    public Ingredient ingredient;
+    public Lazy<Ingredient> ingredient;
     public int ingredientCount;
     public ItemStack result;
     private int energyPerTick;
@@ -45,7 +46,7 @@ public class StirlingGeneratorRecipe extends VERecipe {
 
     @Override
     public Ingredient getIngredient() {
-        return ingredient;
+        return ingredient.get();
     }
 
     public int getIngredientCount() {
@@ -61,7 +62,7 @@ public class StirlingGeneratorRecipe extends VERecipe {
     public boolean matches(Container inv, Level worldIn){
         ItemStack stack = inv.getItem(0);
         int count = stack.getCount();
-        return ingredient.test(stack) && count >= ingredientCount;
+        return ingredient.get().test(stack) && count >= ingredientCount;
     }
 
     @Override
@@ -110,12 +111,12 @@ public class StirlingGeneratorRecipe extends VERecipe {
 
             StirlingGeneratorRecipe recipe = new StirlingGeneratorRecipe(recipeId);
 
-            recipe.ingredient = Ingredient.fromJson(json.get("ingredient"));
+            recipe.ingredient = Lazy.of(() -> Ingredient.fromJson(json.get("ingredient")));
             recipe.ingredientCount = GsonHelper.getAsInt(json.get("ingredient").getAsJsonObject(),"count",1);
             recipe.processTime = GsonHelper.getAsInt(json, "process_time", 200);
             recipe.energyPerTick  = GsonHelper.getAsInt(json, "energy_per_tick", Config.STIRLING_GENERATOR_GENERATE.get());
 
-            for (ItemStack stack : recipe.ingredient.getItems()){
+            for (ItemStack stack : recipe.ingredient.get().getItems()){
                 if (!ingredientList.contains(stack.getItem())){
                     ingredientList.add(stack.getItem());
                 }
@@ -135,7 +136,7 @@ public class StirlingGeneratorRecipe extends VERecipe {
         @Override
         public StirlingGeneratorRecipe fromNetwork(ResourceLocation recipeId, FriendlyByteBuf buffer){
             StirlingGeneratorRecipe recipe = new StirlingGeneratorRecipe(recipeId);
-            recipe.ingredient = Ingredient.fromNetwork(buffer);
+            recipe.ingredient = Lazy.of(() -> Ingredient.fromNetwork(buffer));
             recipe.ingredientCount = buffer.readByte();
             recipe.processTime = buffer.readInt();
             recipe.energyPerTick = buffer.readInt();
@@ -145,7 +146,7 @@ public class StirlingGeneratorRecipe extends VERecipe {
 
         @Override
         public void toNetwork(FriendlyByteBuf buffer, StirlingGeneratorRecipe recipe){
-            recipe.ingredient.toNetwork(buffer);
+            recipe.ingredient.get().toNetwork(buffer);
             buffer.writeByte(recipe.getIngredientCount());
             buffer.writeInt(recipe.processTime);
             buffer.writeInt(recipe.energyPerTick);

--- a/src/main/java/com/veteam/voluminousenergy/recipe/VEFluidRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/VEFluidRecipe.java
@@ -10,6 +10,7 @@ import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.material.Fluid;
+import net.minecraftforge.common.util.Lazy;
 import net.minecraftforge.fluids.FluidStack;
 
 import java.util.ArrayList;
@@ -17,7 +18,7 @@ import java.util.List;
 
 public abstract class VEFluidRecipe implements Recipe<Container> {
 
-    public Ingredient ingredient;
+    public Lazy<Ingredient> ingredient;
     public int ingredientCount;
     public ItemStack result;
 
@@ -26,7 +27,7 @@ public abstract class VEFluidRecipe implements Recipe<Container> {
     }
 
     public Ingredient getIngredient() {
-        return ingredient;
+        return ingredient.get();
     }
 
     public int getIngredientCount() {
@@ -39,7 +40,7 @@ public abstract class VEFluidRecipe implements Recipe<Container> {
     public boolean matches(Container inv, Level worldIn){
         ItemStack stack = inv.getItem(0);
         int count = stack.getCount();
-        return ingredient.test(stack) && count >= ingredientCount;
+        return ingredient.get().test(stack) && count >= ingredientCount;
     }
     @Override
     public ItemStack assemble(Container inv){

--- a/src/main/java/com/veteam/voluminousenergy/recipe/VERecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/VERecipe.java
@@ -8,16 +8,17 @@ import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.util.Lazy;
 
 public class VERecipe  implements Recipe<Container> {
 
-    public Ingredient ingredient;
+    public Lazy<Ingredient> ingredient;
     public int ingredientCount;
     public ItemStack result;
 
 
     public Ingredient getIngredient() {
-        return ingredient;
+        return ingredient.get();
     }
 
     public int getIngredientCount() {
@@ -30,7 +31,7 @@ public class VERecipe  implements Recipe<Container> {
     public boolean matches(Container inv, Level worldIn){
         ItemStack stack = inv.getItem(0);
         int count = stack.getCount();
-        return ingredient.test(stack) && count >= ingredientCount;
+        return ingredient.get().test(stack) && count >= ingredientCount;
     }
     @Override
     public ItemStack assemble(Container inv){

--- a/src/main/java/com/veteam/voluminousenergy/util/RecipeUtil.java
+++ b/src/main/java/com/veteam/voluminousenergy/util/RecipeUtil.java
@@ -394,7 +394,7 @@ public class RecipeUtil {
 
         world.getRecipeManager().getRecipes().parallelStream().forEach(recipe -> {
             if (recipe instanceof StirlingGeneratorRecipe){
-                for (ItemStack itemStack : ((StirlingGeneratorRecipe) recipe).ingredient.getItems()) {
+                for (ItemStack itemStack : ((StirlingGeneratorRecipe) recipe).getIngredient().getItems()) {
                     if (itemStack.getItem() == solidFuelStack.getItem()){
                         atomicRecipe.set((StirlingGeneratorRecipe) recipe);
                         break;


### PR DESCRIPTION
Convert primary ingredient to lazies to fix issues with tags as per [Forge Issue #8498](https://github.com/MinecraftForge/MinecraftForge/issues/8498#issuecomment-1059834285), also pull in Oxidizer recipe fix as `saneAdd` no longer needed and if used doesn't work the way it was intended in 1.18.1 and older (should deprecate and so far seems safe to remove as Oxidizer cache doesn't seem to have dupe issues, and therefore no need to have sane add to prevent cache content duplication or dedup of objects in static cache).