### PR TITLE
Add FluidStack tooltip to TankBlock item

### DIFF
--- a/src/main/java/com/veteam/voluminousenergy/blocks/blocks/machines/tanks/AluminumTankBlock.java
+++ b/src/main/java/com/veteam/voluminousenergy/blocks/blocks/machines/tanks/AluminumTankBlock.java
@@ -4,6 +4,8 @@ import com.veteam.voluminousenergy.blocks.blocks.VEBlocks;
 import com.veteam.voluminousenergy.blocks.tiles.tank.AluminumTankTile;
 import com.veteam.voluminousenergy.blocks.tiles.tank.TankTile;
 import com.veteam.voluminousenergy.datagen.VETagDataGenerator;
+import com.veteam.voluminousenergy.tools.Config;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.EntityBlock;
@@ -48,6 +50,11 @@ public class AluminumTankBlock extends TankBlock implements EntityBlock {
     @Nullable
     public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level level, BlockState state, BlockEntityType<T> blockEntityType) {
         return createTicker(level, blockEntityType, VEBlocks.ALUMINUM_TANK_TILE);
+    }
+
+    @Override
+    public int getTankCapacity() {
+        return Config.ALUMINUM_TANK_CAPACITY.get();
     }
 
 

--- a/src/main/java/com/veteam/voluminousenergy/blocks/blocks/machines/tanks/EighzoTankBlock.java
+++ b/src/main/java/com/veteam/voluminousenergy/blocks/blocks/machines/tanks/EighzoTankBlock.java
@@ -4,6 +4,8 @@ import com.veteam.voluminousenergy.blocks.blocks.VEBlocks;
 import com.veteam.voluminousenergy.blocks.tiles.tank.EighzoTankTile;
 import com.veteam.voluminousenergy.blocks.tiles.tank.TankTile;
 import com.veteam.voluminousenergy.datagen.VETagDataGenerator;
+import com.veteam.voluminousenergy.tools.Config;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.EntityBlock;
@@ -48,6 +50,11 @@ public class EighzoTankBlock extends TankBlock implements EntityBlock {
     @Nullable
     public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level level, BlockState state, BlockEntityType<T> blockEntityType) {
         return createTicker(level, blockEntityType, VEBlocks.EIGHZO_TANK_TILE);
+    }
+
+    @Override
+    public int getTankCapacity() {
+        return Config.EIGHZO_TANK_CAPACITY.get();
     }
 
 }

--- a/src/main/java/com/veteam/voluminousenergy/blocks/blocks/machines/tanks/NetheriteTankBlock.java
+++ b/src/main/java/com/veteam/voluminousenergy/blocks/blocks/machines/tanks/NetheriteTankBlock.java
@@ -4,6 +4,8 @@ import com.veteam.voluminousenergy.blocks.blocks.VEBlocks;
 import com.veteam.voluminousenergy.blocks.tiles.tank.NetheriteTankTile;
 import com.veteam.voluminousenergy.blocks.tiles.tank.TankTile;
 import com.veteam.voluminousenergy.datagen.VETagDataGenerator;
+import com.veteam.voluminousenergy.tools.Config;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.EntityBlock;
@@ -48,6 +50,11 @@ public class NetheriteTankBlock extends TankBlock implements EntityBlock {
     @Nullable
     public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level level, BlockState state, BlockEntityType<T> blockEntityType) {
         return createTicker(level, blockEntityType, VEBlocks.NETHERITE_TANK_TILE);
+    }
+
+    @Override
+    public int getTankCapacity() {
+        return Config.NETHERITE_TANK_CAPACITY.get();
     }
 
 }

--- a/src/main/java/com/veteam/voluminousenergy/blocks/blocks/machines/tanks/NighaliteTankBlock.java
+++ b/src/main/java/com/veteam/voluminousenergy/blocks/blocks/machines/tanks/NighaliteTankBlock.java
@@ -4,6 +4,8 @@ import com.veteam.voluminousenergy.blocks.blocks.VEBlocks;
 import com.veteam.voluminousenergy.blocks.tiles.tank.NighaliteTankTile;
 import com.veteam.voluminousenergy.blocks.tiles.tank.TankTile;
 import com.veteam.voluminousenergy.datagen.VETagDataGenerator;
+import com.veteam.voluminousenergy.tools.Config;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.EntityBlock;
@@ -48,6 +50,11 @@ public class NighaliteTankBlock extends TankBlock implements EntityBlock {
     @Nullable
     public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level level, BlockState state, BlockEntityType<T> blockEntityType) {
         return createTicker(level, blockEntityType, VEBlocks.NIGHALITE_TANK_TILE);
+    }
+
+    @Override
+    public int getTankCapacity() {
+        return Config.NIGHALITE_TANK_CAPACITY.get();
     }
 
 }

--- a/src/main/java/com/veteam/voluminousenergy/blocks/blocks/machines/tanks/SolariumTankBlock.java
+++ b/src/main/java/com/veteam/voluminousenergy/blocks/blocks/machines/tanks/SolariumTankBlock.java
@@ -4,6 +4,8 @@ import com.veteam.voluminousenergy.blocks.blocks.VEBlocks;
 import com.veteam.voluminousenergy.blocks.tiles.tank.SolariumTankTile;
 import com.veteam.voluminousenergy.blocks.tiles.tank.TankTile;
 import com.veteam.voluminousenergy.datagen.VETagDataGenerator;
+import com.veteam.voluminousenergy.tools.Config;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.EntityBlock;
@@ -48,6 +50,11 @@ public class SolariumTankBlock extends TankBlock implements EntityBlock {
     @Nullable
     public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level level, BlockState state, BlockEntityType<T> blockEntityType) {
         return createTicker(level, blockEntityType, VEBlocks.SOLARIUM_TANK_TILE);
+    }
+
+    @Override
+    public int getTankCapacity() {
+        return Config.SOLARIUM_TANK_CAPACITY.get();
     }
 
 }

--- a/src/main/java/com/veteam/voluminousenergy/blocks/blocks/machines/tanks/TankBlock.java
+++ b/src/main/java/com/veteam/voluminousenergy/blocks/blocks/machines/tanks/TankBlock.java
@@ -1,19 +1,33 @@
 package com.veteam.voluminousenergy.blocks.blocks.machines.tanks;
 
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.List;
+
 import com.veteam.voluminousenergy.blocks.blocks.util.FaceableBlock;
 import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.MenuProvider;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.capability.templates.FluidTank;
 import net.minecraftforge.network.NetworkHooks;
 
 public class TankBlock extends FaceableBlock {
+
+    private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("###,###");
 
     public TankBlock(Properties properties){ super(properties); }
 
@@ -29,5 +43,28 @@ public class TankBlock extends FaceableBlock {
             return InteractionResult.SUCCESS;
         }
         return InteractionResult.SUCCESS;
+    }
+
+    @Override
+    public void appendHoverText(ItemStack stack, BlockGetter level, List<Component> tooltip, TooltipFlag flag) {
+        super.appendHoverText(stack, level, tooltip, flag);
+        CompoundTag tag = stack.getTag();
+        FluidStack fluid;
+        if (tag != null) {
+            CompoundTag blockEntityTag = tag.getCompound("BlockEntityTag");
+            CompoundTag tankTag = blockEntityTag.getCompound("tank");
+            FluidTank tank = new FluidTank(0);
+            tank.readFromNBT(tankTag);
+            fluid = tank.getFluid();
+        } else {
+            fluid = FluidStack.EMPTY;
+        }
+        String amount = String.format("%s mB", DECIMAL_FORMAT.format(fluid.getAmount()));
+        String capacity = String.format("%s mB", DECIMAL_FORMAT.format(this.getTankCapacity() * 1000));
+        tooltip.add(new TranslatableComponent("%1$s: %2$s / %3$s", fluid.getDisplayName(), amount, capacity));
+    }
+    
+    public int getTankCapacity() {
+        return 0;
     }
 }

--- a/src/main/java/com/veteam/voluminousenergy/blocks/blocks/machines/tanks/TitaniumTankBlock.java
+++ b/src/main/java/com/veteam/voluminousenergy/blocks/blocks/machines/tanks/TitaniumTankBlock.java
@@ -4,6 +4,8 @@ import com.veteam.voluminousenergy.blocks.blocks.VEBlocks;
 import com.veteam.voluminousenergy.blocks.tiles.tank.TankTile;
 import com.veteam.voluminousenergy.blocks.tiles.tank.TitaniumTankTile;
 import com.veteam.voluminousenergy.datagen.VETagDataGenerator;
+import com.veteam.voluminousenergy.tools.Config;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.EntityBlock;
@@ -48,6 +50,11 @@ public class TitaniumTankBlock extends TankBlock implements EntityBlock {
     @Nullable
     public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level level, BlockState state, BlockEntityType<T> blockEntityType) {
         return createTicker(level, blockEntityType, VEBlocks.TITANIUM_TANK_TILE);
+    }
+
+    @Override
+    public int getTankCapacity() {
+        return Config.TITANIUM_TANK_CAPACITY.get();
     }
 
 


### PR DESCRIPTION
1. Read tank data from item's nbt tag,
2. It tag from Loot Table or Ctrl+Wheel click
3. Add tank's FluidStack tooltip to TankBlock's item
4. Tooltip format peek from CombustionMultitool
---
Empty Tank in Creative Tab

![image](https://user-images.githubusercontent.com/44163945/157364040-f43736de-76f8-4e0e-9ede-72e087d3cf74.png)
![image](https://user-images.githubusercontent.com/44163945/157364048-5cd64c9b-c188-42a2-8c35-091f3487d68f.png)

---
Oxygen 1000 mB in Tank
![image](https://user-images.githubusercontent.com/44163945/157364077-1d9aa45c-5756-4d1c-a222-0dcc22b743fe.png)
