### PR TITLE
1.18.2 Recipe fixes for Dedicated Server

### DIFF
--- a/src/main/java/com/veteam/voluminousenergy/blocks/tiles/PrimitiveBlastFurnaceTile.java
+++ b/src/main/java/com/veteam/voluminousenergy/blocks/tiles/PrimitiveBlastFurnaceTile.java
@@ -119,7 +119,7 @@ public class PrimitiveBlastFurnaceTile extends VoluminousTileEntity implements I
                 PrimitiveBlastFurnaceRecipe recipe = level.getRecipeManager().getRecipeFor(PrimitiveBlastFurnaceRecipe.RECIPE_TYPE, new SimpleContainer(referenceStack),level).orElse(null);
 
                 if (slot == 0 && recipe != null){
-                    return recipe.ingredient.test(stack);
+                    return recipe.ingredient.get().test(stack);
                 } else if (slot == 1 && recipeOutput != null){
                     return stack.getItem() == recipeOutput.result.getItem();
                 } else if (slot == 2){
@@ -137,7 +137,7 @@ public class PrimitiveBlastFurnaceTile extends VoluminousTileEntity implements I
                 PrimitiveBlastFurnaceRecipe recipe = level.getRecipeManager().getRecipeFor(PrimitiveBlastFurnaceRecipe.RECIPE_TYPE, new SimpleContainer(referenceStack),level).orElse(null);
 
                 if(slot == 0 && recipe != null) {
-                    for (ItemStack testStack : recipe.ingredient.getItems()){
+                    for (ItemStack testStack : recipe.ingredient.get().getItems()){
                         if(stack.getItem() == testStack.getItem()){
                             return super.insertItem(slot, stack, simulate);
                         }

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/category/IndustrialBlastingCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/category/IndustrialBlastingCategory.java
@@ -27,6 +27,7 @@ import net.minecraftforge.registries.ForgeRegistries;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class IndustrialBlastingCategory implements IRecipeCategory<IndustrialBlastingRecipe> {
 
@@ -136,11 +137,10 @@ public class IndustrialBlastingCategory implements IRecipeCategory<IndustrialBla
 
         // Should only be one ingredient...
         List<ItemStack> inputs = new ArrayList<>();
-        Arrays.stream(recipe.getIngredient().getItems()).map(s -> {
-            ItemStack stack = s.copy();
-            stack.setCount(recipe.getIngredientCount());
-            return stack;
-        }).forEach(inputs::add);
+        AtomicReference<List<ItemStack>> atomicInputs = new AtomicReference<>(inputs);
+        recipe.ingredientList.get().forEach(ingredient ->{
+            atomicInputs.get().add(new ItemStack(ingredient, recipe.ingredientCount));
+        });
         itemStacks.set(0, inputs);
 
         List<ItemStack> seconds = new ArrayList<>();

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/category/IndustrialBlastingCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/category/IndustrialBlastingCategory.java
@@ -25,7 +25,6 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.registries.ForgeRegistries;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -138,7 +137,7 @@ public class IndustrialBlastingCategory implements IRecipeCategory<IndustrialBla
         // Should only be one ingredient...
         List<ItemStack> inputs = new ArrayList<>();
         AtomicReference<List<ItemStack>> atomicInputs = new AtomicReference<>(inputs);
-        recipe.ingredientList.get().forEach(ingredient ->{
+        recipe.getFirstInputAsList().forEach(ingredient ->{
             atomicInputs.get().add(new ItemStack(ingredient, recipe.ingredientCount));
         });
         itemStacks.set(0, inputs);

--- a/src/main/java/com/veteam/voluminousenergy/recipe/AqueoulizerRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/AqueoulizerRecipe.java
@@ -22,7 +22,6 @@ import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.ForgeRegistryEntry;
 
 import javax.annotation.Nullable;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -177,9 +176,7 @@ public class AqueoulizerRecipe extends VEFluidRecipe {
             recipe.fluidUsesTagKey = buffer.readBoolean();
 
             if (recipe.fluidUsesTagKey){
-                int sequenceLength = buffer.readInt();
-                recipe.tagKeyString = buffer.readCharSequence(sequenceLength, StandardCharsets.UTF_8).toString();
-                ResourceLocation fluidTagLocation = new ResourceLocation(recipe.tagKeyString);
+                ResourceLocation fluidTagLocation = buffer.readResourceLocation();
                 recipe.rawFluidInputList = TagUtil.getLazyFluids(fluidTagLocation);
                 recipe.fluidInputList = TagUtil.getLazyFluidStacks(fluidTagLocation, recipe.inputAmount);
                 recipe.inputArraySize = Lazy.of(() -> recipe.fluidInputList.get().size());
@@ -212,8 +209,7 @@ public class AqueoulizerRecipe extends VEFluidRecipe {
             buffer.writeBoolean(recipe.fluidUsesTagKey);
 
             if (recipe.fluidUsesTagKey){
-                buffer.writeInt(recipe.tagKeyString.length());
-                buffer.writeCharSequence(recipe.tagKeyString, StandardCharsets.UTF_8);
+                buffer.writeResourceLocation(new ResourceLocation(recipe.tagKeyString));
             } else { // does not use tags for fluid input
                 buffer.writeInt(recipe.inputArraySize.get());
                 for(int i = 0; i < recipe.inputArraySize.get(); i++){

--- a/src/main/java/com/veteam/voluminousenergy/recipe/AqueoulizerRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/AqueoulizerRecipe.java
@@ -171,6 +171,7 @@ public class AqueoulizerRecipe extends VEFluidRecipe {
         @Override
         public AqueoulizerRecipe fromNetwork(ResourceLocation recipeId, FriendlyByteBuf buffer){
             AqueoulizerRecipe recipe = new AqueoulizerRecipe((recipeId));
+            recipe.inputAmount = buffer.readInt();
 
             // Start with usesTagKey check
             recipe.fluidUsesTagKey = buffer.readBoolean();
@@ -196,7 +197,6 @@ public class AqueoulizerRecipe extends VEFluidRecipe {
 
             recipe.ingredientCount = buffer.readInt();
             recipe.result = buffer.readFluidStack();
-            recipe.inputAmount = buffer.readInt();
             recipe.processTime = buffer.readInt();
             recipe.outputAmount = buffer.readInt();
             Ingredient tempIngredient = Ingredient.fromNetwork(buffer);
@@ -206,6 +206,7 @@ public class AqueoulizerRecipe extends VEFluidRecipe {
 
         @Override
         public void toNetwork(FriendlyByteBuf buffer, AqueoulizerRecipe recipe){
+            buffer.writeInt(recipe.inputAmount);
             buffer.writeBoolean(recipe.fluidUsesTagKey);
 
             if (recipe.fluidUsesTagKey){
@@ -219,7 +220,6 @@ public class AqueoulizerRecipe extends VEFluidRecipe {
 
             buffer.writeInt(recipe.ingredientCount);
             buffer.writeFluidStack(recipe.result);
-            buffer.writeInt(recipe.inputAmount);
             buffer.writeInt(recipe.processTime);
             buffer.writeInt(recipe.outputAmount);
 

--- a/src/main/java/com/veteam/voluminousenergy/recipe/AqueoulizerRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/AqueoulizerRecipe.java
@@ -6,7 +6,6 @@ import com.veteam.voluminousenergy.blocks.blocks.VEBlocks;
 import com.veteam.voluminousenergy.util.RecipeUtil;
 import com.veteam.voluminousenergy.util.TagUtil;
 import net.minecraft.network.FriendlyByteBuf;
-import net.minecraft.network.chat.TextComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.GsonHelper;
 import net.minecraft.world.Container;
@@ -23,6 +22,7 @@ import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.ForgeRegistryEntry;
 
 import javax.annotation.Nullable;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -177,7 +177,8 @@ public class AqueoulizerRecipe extends VEFluidRecipe {
             recipe.fluidUsesTagKey = buffer.readBoolean();
 
             if (recipe.fluidUsesTagKey){
-                recipe.tagKeyString = buffer.readComponent().getContents();
+                int sequenceLength = buffer.readInt();
+                recipe.tagKeyString = buffer.readCharSequence(sequenceLength, StandardCharsets.UTF_8).toString();
                 ResourceLocation fluidTagLocation = new ResourceLocation(recipe.tagKeyString);
                 recipe.rawFluidInputList = TagUtil.getLazyFluids(fluidTagLocation);
                 recipe.fluidInputList = TagUtil.getLazyFluidStacks(fluidTagLocation, recipe.inputAmount);
@@ -210,7 +211,8 @@ public class AqueoulizerRecipe extends VEFluidRecipe {
             buffer.writeBoolean(recipe.fluidUsesTagKey);
 
             if (recipe.fluidUsesTagKey){
-                buffer.writeComponent(new TextComponent(recipe.tagKeyString));
+                buffer.writeInt(recipe.tagKeyString.length());
+                buffer.writeCharSequence(recipe.tagKeyString, StandardCharsets.UTF_8);
             } else { // does not use tags for fluid input
                 buffer.writeInt(recipe.inputArraySize.get());
                 for(int i = 0; i < recipe.inputArraySize.get(); i++){

--- a/src/main/java/com/veteam/voluminousenergy/recipe/AqueoulizerRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/AqueoulizerRecipe.java
@@ -202,7 +202,8 @@ public class AqueoulizerRecipe extends VEFluidRecipe {
             recipe.inputAmount = buffer.readInt();
             recipe.processTime = buffer.readInt();
             recipe.outputAmount = buffer.readInt();
-            recipe.ingredient = Lazy.of(() -> Ingredient.fromNetwork(buffer));
+            Ingredient tempIngredient = Ingredient.fromNetwork(buffer);
+            recipe.ingredient = Lazy.of(() -> tempIngredient);
             return recipe;
         }
 

--- a/src/main/java/com/veteam/voluminousenergy/recipe/CentrifugalAgitatorRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/CentrifugalAgitatorRecipe.java
@@ -217,7 +217,8 @@ public class CentrifugalAgitatorRecipe extends VEFluidRecipe {
             recipe.secondResult = buffer.readFluidStack();
             recipe.secondAmount = buffer.readInt();
 
-            recipe.ingredient = Lazy.of(() -> Ingredient.fromNetwork(buffer));
+            Ingredient tempIngredient = Ingredient.fromNetwork(buffer);
+            recipe.ingredient = Lazy.of(() -> tempIngredient);
 
             return recipe;
         }

--- a/src/main/java/com/veteam/voluminousenergy/recipe/CentrifugalAgitatorRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/CentrifugalAgitatorRecipe.java
@@ -6,7 +6,6 @@ import com.veteam.voluminousenergy.blocks.blocks.VEBlocks;
 import com.veteam.voluminousenergy.util.RecipeUtil;
 import com.veteam.voluminousenergy.util.TagUtil;
 import net.minecraft.network.FriendlyByteBuf;
-import net.minecraft.network.chat.TextComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.GsonHelper;
 import net.minecraft.world.Container;
@@ -23,6 +22,7 @@ import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.ForgeRegistryEntry;
 
 import javax.annotation.Nullable;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -190,7 +190,8 @@ public class CentrifugalAgitatorRecipe extends VEFluidRecipe {
             recipe.fluidUsesTagKey = buffer.readBoolean();
 
             if (recipe.fluidUsesTagKey){
-                recipe.tagKeyString = buffer.readComponent().getContents();
+                int sequenceLength = buffer.readInt();
+                recipe.tagKeyString = buffer.readCharSequence(sequenceLength, StandardCharsets.UTF_8).toString();
                 ResourceLocation fluidTagLocation = new ResourceLocation(recipe.tagKeyString);
                 recipe.rawFluidInputList = TagUtil.getLazyFluids(fluidTagLocation);
                 recipe.fluidInputList = TagUtil.getLazyFluidStacks(fluidTagLocation, 1000);
@@ -228,7 +229,8 @@ public class CentrifugalAgitatorRecipe extends VEFluidRecipe {
             buffer.writeBoolean(recipe.fluidUsesTagKey);
 
             if (recipe.fluidUsesTagKey){
-                buffer.writeComponent(new TextComponent(recipe.tagKeyString));
+                buffer.writeInt(recipe.tagKeyString.length());
+                buffer.writeCharSequence(recipe.tagKeyString, StandardCharsets.UTF_8);
             } else { // does not use tags for fluid input
                 buffer.writeInt(recipe.inputArraySize.get());
                 for(int i = 0; i < recipe.inputArraySize.get(); i++){

--- a/src/main/java/com/veteam/voluminousenergy/recipe/CentrifugalAgitatorRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/CentrifugalAgitatorRecipe.java
@@ -22,7 +22,6 @@ import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.ForgeRegistryEntry;
 
 import javax.annotation.Nullable;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -190,9 +189,7 @@ public class CentrifugalAgitatorRecipe extends VEFluidRecipe {
             recipe.fluidUsesTagKey = buffer.readBoolean();
 
             if (recipe.fluidUsesTagKey){
-                int sequenceLength = buffer.readInt();
-                recipe.tagKeyString = buffer.readCharSequence(sequenceLength, StandardCharsets.UTF_8).toString();
-                ResourceLocation fluidTagLocation = new ResourceLocation(recipe.tagKeyString);
+                ResourceLocation fluidTagLocation = buffer.readResourceLocation();
                 recipe.rawFluidInputList = TagUtil.getLazyFluids(fluidTagLocation);
                 recipe.fluidInputList = TagUtil.getLazyFluidStacks(fluidTagLocation, 1000);
                 recipe.inputArraySize = Lazy.of(() -> recipe.fluidInputList.get().size());
@@ -230,8 +227,7 @@ public class CentrifugalAgitatorRecipe extends VEFluidRecipe {
             buffer.writeBoolean(recipe.fluidUsesTagKey);
 
             if (recipe.fluidUsesTagKey){
-                buffer.writeInt(recipe.tagKeyString.length());
-                buffer.writeCharSequence(recipe.tagKeyString, StandardCharsets.UTF_8);
+                buffer.writeResourceLocation(new ResourceLocation(recipe.tagKeyString));
             } else { // does not use tags for fluid input
                 buffer.writeInt(recipe.inputArraySize.get());
                 for(int i = 0; i < recipe.inputArraySize.get(); i++){

--- a/src/main/java/com/veteam/voluminousenergy/recipe/CentrifugalAgitatorRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/CentrifugalAgitatorRecipe.java
@@ -184,6 +184,7 @@ public class CentrifugalAgitatorRecipe extends VEFluidRecipe {
         public CentrifugalAgitatorRecipe fromNetwork(ResourceLocation recipeId, FriendlyByteBuf buffer){
             CentrifugalAgitatorRecipe recipe = new CentrifugalAgitatorRecipe((recipeId));
             recipe.ingredientCount = buffer.readByte();
+            recipe.inputAmount = buffer.readInt();
 
             // Start with usesTagKey check
             recipe.fluidUsesTagKey = buffer.readBoolean();
@@ -191,7 +192,7 @@ public class CentrifugalAgitatorRecipe extends VEFluidRecipe {
             if (recipe.fluidUsesTagKey){
                 ResourceLocation fluidTagLocation = buffer.readResourceLocation();
                 recipe.rawFluidInputList = TagUtil.getLazyFluids(fluidTagLocation);
-                recipe.fluidInputList = TagUtil.getLazyFluidStacks(fluidTagLocation, 1000);
+                recipe.fluidInputList = TagUtil.getLazyFluidStacks(fluidTagLocation, recipe.inputAmount);
                 recipe.inputArraySize = Lazy.of(() -> recipe.fluidInputList.get().size());
             } else {
                 recipe.inputArraySize = Lazy.of(buffer::readInt);
@@ -208,7 +209,6 @@ public class CentrifugalAgitatorRecipe extends VEFluidRecipe {
             }
 
             recipe.result = buffer.readFluidStack();
-            recipe.inputAmount = buffer.readInt();
             recipe.processTime = buffer.readInt();
             recipe.outputAmount = buffer.readInt();
             recipe.secondResult = buffer.readFluidStack();
@@ -223,6 +223,7 @@ public class CentrifugalAgitatorRecipe extends VEFluidRecipe {
         @Override
         public void toNetwork(FriendlyByteBuf buffer, CentrifugalAgitatorRecipe recipe){
             buffer.writeByte(recipe.getIngredientCount());
+            buffer.writeInt(recipe.inputAmount);
 
             buffer.writeBoolean(recipe.fluidUsesTagKey);
 
@@ -236,7 +237,6 @@ public class CentrifugalAgitatorRecipe extends VEFluidRecipe {
             }
 
             buffer.writeFluidStack(recipe.result);
-            buffer.writeInt(recipe.inputAmount);
             buffer.writeInt(recipe.processTime);
             buffer.writeInt(recipe.outputAmount);
             buffer.writeFluidStack(recipe.secondResult);

--- a/src/main/java/com/veteam/voluminousenergy/recipe/CentrifugalSeparatorRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/CentrifugalSeparatorRecipe.java
@@ -184,7 +184,8 @@ public class CentrifugalSeparatorRecipe extends VERecipe{
             recipe.chance2 = buffer.readFloat();
 
             // Lazies
-            recipe.ingredient = Lazy.of(() -> Ingredient.fromNetwork(buffer));
+            Ingredient tempIngredient = Ingredient.fromNetwork(buffer);
+            recipe.ingredient = Lazy.of(() -> tempIngredient);
 
             return recipe;
         }

--- a/src/main/java/com/veteam/voluminousenergy/recipe/CombustionGenerator/CombustionGeneratorFuelRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/CombustionGenerator/CombustionGeneratorFuelRecipe.java
@@ -8,7 +8,6 @@ import com.veteam.voluminousenergy.recipe.VERecipes;
 import com.veteam.voluminousenergy.util.RecipeUtil;
 import com.veteam.voluminousenergy.util.TagUtil;
 import net.minecraft.network.FriendlyByteBuf;
-import net.minecraft.network.chat.TextComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.GsonHelper;
 import net.minecraft.world.Container;
@@ -28,6 +27,7 @@ import net.minecraftforge.registries.ForgeRegistryEntry;
 import oshi.util.tuples.Pair;
 
 import javax.annotation.Nullable;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 public class CombustionGeneratorFuelRecipe extends VEFluidRecipe {
@@ -192,7 +192,8 @@ public class CombustionGeneratorFuelRecipe extends VEFluidRecipe {
             recipe.fluidUsesTagKey = buffer.readBoolean();
 
             if (recipe.fluidUsesTagKey){
-                recipe.tagKeyString = buffer.readComponent().getContents();
+                int sequenceLength = buffer.readInt();
+                recipe.tagKeyString = buffer.readCharSequence(sequenceLength, StandardCharsets.UTF_8).toString();
                 ResourceLocation fluidTagLocation = new ResourceLocation(recipe.tagKeyString);
                 recipe.rawFluidInputList = TagUtil.getLazyFluids(fluidTagLocation);
                 recipe.fluidInputList = TagUtil.getLazyFluidStacks(fluidTagLocation, 1000);
@@ -227,7 +228,8 @@ public class CombustionGeneratorFuelRecipe extends VEFluidRecipe {
             buffer.writeBoolean(recipe.fluidUsesTagKey);
 
             if (recipe.fluidUsesTagKey){
-                buffer.writeComponent(new TextComponent(recipe.tagKeyString));
+                buffer.writeInt(recipe.tagKeyString.length());
+                buffer.writeCharSequence(recipe.tagKeyString, StandardCharsets.UTF_8);
             } else { // does not use tags for fluid input
                 buffer.writeInt(recipe.inputArraySize.get());
                 for(int i = 0; i < recipe.inputArraySize.get(); i++){

--- a/src/main/java/com/veteam/voluminousenergy/recipe/CombustionGenerator/CombustionGeneratorFuelRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/CombustionGenerator/CombustionGeneratorFuelRecipe.java
@@ -27,7 +27,6 @@ import net.minecraftforge.registries.ForgeRegistryEntry;
 import oshi.util.tuples.Pair;
 
 import javax.annotation.Nullable;
-import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 public class CombustionGeneratorFuelRecipe extends VEFluidRecipe {
@@ -192,9 +191,7 @@ public class CombustionGeneratorFuelRecipe extends VEFluidRecipe {
             recipe.fluidUsesTagKey = buffer.readBoolean();
 
             if (recipe.fluidUsesTagKey){
-                int sequenceLength = buffer.readInt();
-                recipe.tagKeyString = buffer.readCharSequence(sequenceLength, StandardCharsets.UTF_8).toString();
-                ResourceLocation fluidTagLocation = new ResourceLocation(recipe.tagKeyString);
+                ResourceLocation fluidTagLocation = buffer.readResourceLocation();
                 recipe.rawFluidInputList = TagUtil.getLazyFluids(fluidTagLocation);
                 recipe.fluidInputList = TagUtil.getLazyFluidStacks(fluidTagLocation, 1000);
                 recipe.inputArraySize = Lazy.of(() -> recipe.fluidInputList.get().size());
@@ -229,8 +226,7 @@ public class CombustionGeneratorFuelRecipe extends VEFluidRecipe {
             buffer.writeBoolean(recipe.fluidUsesTagKey);
 
             if (recipe.fluidUsesTagKey){
-                buffer.writeInt(recipe.tagKeyString.length());
-                buffer.writeCharSequence(recipe.tagKeyString, StandardCharsets.UTF_8);
+                buffer.writeResourceLocation(new ResourceLocation(recipe.tagKeyString));
             } else { // does not use tags for fluid input
                 buffer.writeInt(recipe.inputArraySize.get());
                 for(int i = 0; i < recipe.inputArraySize.get(); i++){

--- a/src/main/java/com/veteam/voluminousenergy/recipe/CombustionGenerator/CombustionGeneratorFuelRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/CombustionGenerator/CombustionGeneratorFuelRecipe.java
@@ -214,7 +214,8 @@ public class CombustionGeneratorFuelRecipe extends VEFluidRecipe {
 
             recipe.ingredientCount = buffer.readInt();
             recipe.volumetricEnergy = buffer.readInt();
-            recipe.ingredient = Lazy.of(() -> Ingredient.fromNetwork(buffer));
+            Ingredient tempIngredient = Ingredient.fromNetwork(buffer);
+            recipe.ingredient = Lazy.of(() -> tempIngredient);
 
             lazyFluidsWithVolumetricEnergy.add(Lazy.of(() -> new Pair<>(recipe.rawFluidInputList.get(), recipe.volumetricEnergy)));
 

--- a/src/main/java/com/veteam/voluminousenergy/recipe/CombustionGenerator/CombustionGeneratorOxidizerRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/CombustionGenerator/CombustionGeneratorOxidizerRecipe.java
@@ -188,7 +188,8 @@ public class CombustionGeneratorOxidizerRecipe extends VERecipe {
             //});
             if (!atomicBoolean.get()) oxidizerRecipes.add(recipe);
 
-            recipe.ingredient = Lazy.of(() -> Ingredient.fromNetwork(buffer));
+            Ingredient tempIngredient = Ingredient.fromNetwork(buffer);
+            recipe.ingredient = Lazy.of(() -> tempIngredient);
 
             oxidizerRecipes.add(recipe);
             return recipe;

--- a/src/main/java/com/veteam/voluminousenergy/recipe/CombustionGenerator/CombustionGeneratorOxidizerRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/CombustionGenerator/CombustionGeneratorOxidizerRecipe.java
@@ -25,7 +25,6 @@ import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.ForgeRegistryEntry;
 
 import javax.annotation.Nullable;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -158,10 +157,7 @@ public class CombustionGeneratorOxidizerRecipe extends VERecipe {
             recipe.usesTagKey = buffer.readBoolean();
 
             if (recipe.usesTagKey){
-                int sequenceLength = buffer.readInt();
-                recipe.tagKeyString = buffer.readCharSequence(sequenceLength, StandardCharsets.UTF_8).toString();
-
-                ResourceLocation fluidTagLocation = new ResourceLocation(recipe.tagKeyString);
+                ResourceLocation fluidTagLocation = buffer.readResourceLocation();
                 recipe.rawFluidInputList = TagUtil.getLazyFluids(fluidTagLocation);
                 recipe.fluidInputList = TagUtil.getLazyFluidStacks(fluidTagLocation, 1000);
                 recipe.inputArraySize = Lazy.of(() -> recipe.fluidInputList.get().size());
@@ -202,8 +198,7 @@ public class CombustionGeneratorOxidizerRecipe extends VERecipe {
             buffer.writeBoolean(recipe.usesTagKey);
 
             if (recipe.usesTagKey){
-                buffer.writeInt(recipe.tagKeyString.length());
-                buffer.writeCharSequence(recipe.tagKeyString, StandardCharsets.UTF_8);
+                buffer.writeResourceLocation(new ResourceLocation(recipe.tagKeyString));
             } else {
                 buffer.writeInt(recipe.inputArraySize.get());
                 for(int i = 0; i < recipe.inputArraySize.get(); i++){

--- a/src/main/java/com/veteam/voluminousenergy/recipe/CompressorRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/CompressorRecipe.java
@@ -128,7 +128,8 @@ public class CompressorRecipe extends VERecipe {
             recipe.processTime = buffer.readInt();
             recipe.outputAmount = buffer.readInt();
 
-            recipe.ingredient = Lazy.of(() -> Ingredient.fromNetwork(buffer));
+            Ingredient tempIngredient = Ingredient.fromNetwork(buffer);
+            recipe.ingredient = Lazy.of(() -> tempIngredient);
 
             return recipe;
         }

--- a/src/main/java/com/veteam/voluminousenergy/recipe/CrusherRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/CrusherRecipe.java
@@ -131,7 +131,8 @@ public class CrusherRecipe extends VERecipe {
             recipe.outputRngAmount = buffer.readInt();
             recipe.chance = buffer.readFloat();
 
-            recipe.ingredient = Lazy.of(() -> Ingredient.fromNetwork(buffer));
+            Ingredient tempIngredient = Ingredient.fromNetwork(buffer);
+            recipe.ingredient = Lazy.of(() -> tempIngredient);
 
             return recipe;
         }

--- a/src/main/java/com/veteam/voluminousenergy/recipe/DistillationRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/DistillationRecipe.java
@@ -211,6 +211,7 @@ public class DistillationRecipe extends VEFluidRecipe {
             DistillationRecipe recipe = new DistillationRecipe((recipeId));
             recipe.ingredientCount = buffer.readByte();
             recipe.result = buffer.readFluidStack();
+            recipe.inputAmount = buffer.readInt();
 
             // This is probably not great, but eh, what else am I supposed to do in this situation?
             recipe.fluidUsesTagKey = buffer.readBoolean();
@@ -221,10 +222,11 @@ public class DistillationRecipe extends VEFluidRecipe {
                 recipe.fluidInputList = TagUtil.getLazyFluidStacks(fluidTagLocation, recipe.inputAmount);
                 recipe.inputArraySize = Lazy.of(() -> recipe.fluidInputList.get().size());
             } else {
-                recipe.inputArraySize = Lazy.of(buffer::readInt);
+                int inputArraySize = buffer.readInt();
+                recipe.inputArraySize = Lazy.of(() -> inputArraySize);
                 ArrayList<Fluid> fluids = new ArrayList<>();
                 ArrayList<FluidStack> fluidStacks = new ArrayList<>();
-                for (int i = 0; i < recipe.inputArraySize.get(); i++){
+                for (int i = 0; i < inputArraySize; i++){
                     FluidStack serverFluid = buffer.readFluidStack();
                     fluidStacks.add(serverFluid.copy());
                     fluids.add(serverFluid.getRawFluid());
@@ -234,7 +236,6 @@ public class DistillationRecipe extends VEFluidRecipe {
                 recipe.rawFluidInputList = Lazy.of(() -> fluids);
             }
 
-            recipe.inputAmount = buffer.readInt();
             recipe.processTime = buffer.readInt();
             recipe.outputAmount = buffer.readInt();
             recipe.secondResult = buffer.readFluidStack();
@@ -251,6 +252,7 @@ public class DistillationRecipe extends VEFluidRecipe {
         public void toNetwork(FriendlyByteBuf buffer, DistillationRecipe recipe){
             buffer.writeByte(recipe.getIngredientCount());
             buffer.writeFluidStack(recipe.result);
+            buffer.writeInt(recipe.inputAmount);
 
             // Same as the comment in read, not optimal, but necessary
             buffer.writeBoolean(recipe.fluidUsesTagKey);
@@ -264,7 +266,6 @@ public class DistillationRecipe extends VEFluidRecipe {
                 }
             }
 
-            buffer.writeInt(recipe.inputAmount);
             buffer.writeInt(recipe.processTime);
             buffer.writeInt(recipe.outputAmount);
             buffer.writeFluidStack(recipe.secondResult);

--- a/src/main/java/com/veteam/voluminousenergy/recipe/DistillationRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/DistillationRecipe.java
@@ -244,7 +244,8 @@ public class DistillationRecipe extends VEFluidRecipe {
             recipe.secondAmount = buffer.readInt();
             recipe.thirdResult = buffer.readItem();
 
-            recipe.ingredient = Lazy.of(() -> Ingredient.fromNetwork(buffer));
+            Ingredient tempIngredient = Ingredient.fromNetwork(buffer);
+            recipe.ingredient = Lazy.of(() -> tempIngredient);
 
             return recipe;
         }

--- a/src/main/java/com/veteam/voluminousenergy/recipe/DistillationRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/DistillationRecipe.java
@@ -6,7 +6,6 @@ import com.veteam.voluminousenergy.blocks.blocks.VEBlocks;
 import com.veteam.voluminousenergy.util.RecipeUtil;
 import com.veteam.voluminousenergy.util.TagUtil;
 import net.minecraft.network.FriendlyByteBuf;
-import net.minecraft.network.chat.TextComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.GsonHelper;
 import net.minecraft.world.Container;
@@ -23,6 +22,7 @@ import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.ForgeRegistryEntry;
 
 import javax.annotation.Nullable;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -217,7 +217,8 @@ public class DistillationRecipe extends VEFluidRecipe {
             recipe.fluidUsesTagKey = buffer.readBoolean();
 
             if (recipe.fluidUsesTagKey){
-                recipe.tagKeyString = buffer.readComponent().getContents();
+                int sequenceLength = buffer.readInt();
+                recipe.tagKeyString = buffer.readCharSequence(sequenceLength, StandardCharsets.UTF_8).toString();
                 ResourceLocation fluidTagLocation = new ResourceLocation(recipe.tagKeyString);
                 recipe.rawFluidInputList = TagUtil.getLazyFluids(fluidTagLocation);
                 recipe.fluidInputList = TagUtil.getLazyFluidStacks(fluidTagLocation, recipe.inputAmount);
@@ -257,7 +258,8 @@ public class DistillationRecipe extends VEFluidRecipe {
             buffer.writeBoolean(recipe.fluidUsesTagKey);
 
             if (recipe.fluidUsesTagKey){
-                buffer.writeComponent(new TextComponent(recipe.tagKeyString));
+                buffer.writeInt(recipe.tagKeyString.length());
+                buffer.writeCharSequence(recipe.tagKeyString, StandardCharsets.UTF_8);
             } else { // does not use tags for fluid input
                 buffer.writeInt(recipe.inputArraySize.get());
                 for(int i = 0; i < recipe.inputArraySize.get(); i++){

--- a/src/main/java/com/veteam/voluminousenergy/recipe/DistillationRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/DistillationRecipe.java
@@ -22,7 +22,6 @@ import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.ForgeRegistryEntry;
 
 import javax.annotation.Nullable;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -217,9 +216,7 @@ public class DistillationRecipe extends VEFluidRecipe {
             recipe.fluidUsesTagKey = buffer.readBoolean();
 
             if (recipe.fluidUsesTagKey){
-                int sequenceLength = buffer.readInt();
-                recipe.tagKeyString = buffer.readCharSequence(sequenceLength, StandardCharsets.UTF_8).toString();
-                ResourceLocation fluidTagLocation = new ResourceLocation(recipe.tagKeyString);
+                ResourceLocation fluidTagLocation = buffer.readResourceLocation();
                 recipe.rawFluidInputList = TagUtil.getLazyFluids(fluidTagLocation);
                 recipe.fluidInputList = TagUtil.getLazyFluidStacks(fluidTagLocation, recipe.inputAmount);
                 recipe.inputArraySize = Lazy.of(() -> recipe.fluidInputList.get().size());
@@ -259,8 +256,7 @@ public class DistillationRecipe extends VEFluidRecipe {
             buffer.writeBoolean(recipe.fluidUsesTagKey);
 
             if (recipe.fluidUsesTagKey){
-                buffer.writeInt(recipe.tagKeyString.length());
-                buffer.writeCharSequence(recipe.tagKeyString, StandardCharsets.UTF_8);
+                buffer.writeResourceLocation(new ResourceLocation(recipe.tagKeyString));
             } else { // does not use tags for fluid input
                 buffer.writeInt(recipe.inputArraySize.get());
                 for(int i = 0; i < recipe.inputArraySize.get(); i++){

--- a/src/main/java/com/veteam/voluminousenergy/recipe/ElectrolyzerRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/ElectrolyzerRecipe.java
@@ -183,7 +183,8 @@ public class ElectrolyzerRecipe extends VERecipe {
             recipe.outputRngAmount2 = buffer.readInt();
             recipe.chance2 = buffer.readFloat();
 
-            recipe.ingredient = Lazy.of(() -> Ingredient.fromNetwork(buffer));
+            Ingredient tempIngredient = Ingredient.fromNetwork(buffer);
+            recipe.ingredient = Lazy.of(() -> tempIngredient);
 
             return recipe;
         }

--- a/src/main/java/com/veteam/voluminousenergy/recipe/ImplosionCompressorRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/ImplosionCompressorRecipe.java
@@ -128,7 +128,8 @@ public class ImplosionCompressorRecipe extends VERecipe {
             recipe.processTime = buffer.readInt();
             recipe.outputAmount = buffer.readInt();
 
-            recipe.ingredient = Lazy.of(() -> Ingredient.fromNetwork(buffer));
+            Ingredient tempIngredient = Ingredient.fromNetwork(buffer);
+            recipe.ingredient = Lazy.of(() -> tempIngredient);
 
             return recipe;
         }

--- a/src/main/java/com/veteam/voluminousenergy/recipe/IndustrialBlastingRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/IndustrialBlastingRecipe.java
@@ -27,7 +27,7 @@ import java.util.Map;
 
 public class IndustrialBlastingRecipe extends VERecipe {
 
-    public Lazy<ArrayList<Item>> ingredientList;
+    protected Lazy<ArrayList<Item>> ingredientList; // Use getFirstInputAsList, because ingredientCount can't initialize properly without it
     public Lazy<ArrayList<Item>> ingredientListIncludingSeconds;
     public Lazy<ArrayList<Item>> onlySecondInput;
     public final ResourceLocation recipeId;
@@ -38,6 +38,7 @@ public class IndustrialBlastingRecipe extends VERecipe {
 
     protected boolean usesTagKey;
     protected String tagKeyString;
+    Lazy<Integer> tempIngredientCount;
 
     public static final RecipeType<IndustrialBlastingRecipe> RECIPE_TYPE = VERecipes.VERecipeTypes.INDUSTRIAL_BLASTING;
 
@@ -53,6 +54,7 @@ public class IndustrialBlastingRecipe extends VERecipe {
         return ImmutableMap.copyOf(ingredients);
     }
 
+    @Deprecated
     @Override
     public boolean matches(Container inv, Level worldIn){
         ItemStack stack = inv.getItem(0);
@@ -86,7 +88,10 @@ public class IndustrialBlastingRecipe extends VERecipe {
 
     public int getOutputAmount() {return outputAmount;}
 
-    public ArrayList<Item> getFirstInputAsList() { return ingredientList.get(); }
+    public ArrayList<Item> getFirstInputAsList() {
+        if (this.ingredientCount == 0) this.ingredientCount = (tempIngredientCount.get() > 0 ? tempIngredientCount.get() : 1);
+        return ingredientList.get();
+    }
 
     public ItemStack getResult(){
         return result;
@@ -103,9 +108,10 @@ public class IndustrialBlastingRecipe extends VERecipe {
         public IndustrialBlastingRecipe fromJson(ResourceLocation recipeId, JsonObject json){
             IndustrialBlastingRecipe recipe = new IndustrialBlastingRecipe(recipeId);
 
-            recipe.ingredient = Lazy.of(() -> Ingredient.fromJson(json.get("ingredient")));
-            recipe.ingredientCount = GsonHelper.getAsInt(json.get("ingredient").getAsJsonObject(), "count", 1);
+            final JsonObject ingredientJson = json.get("ingredient").getAsJsonObject();
+            recipe.ingredient = Lazy.of(() -> Ingredient.fromJson(ingredientJson));
             recipe.processTime = GsonHelper.getAsInt(json,"process_time",200);
+            recipe.tempIngredientCount = Lazy.of(() -> GsonHelper.getAsInt(ingredientJson, "count", 1));
 
             recipe.ingredientList = Lazy.of(() -> {
                 ArrayList<Item> temp = new ArrayList<>();
@@ -173,23 +179,24 @@ public class IndustrialBlastingRecipe extends VERecipe {
                 recipe.onlySecondInput = Lazy.of(() -> secondInputs);
             }
 
+            ArrayList<Item> firstInputList = new ArrayList<>();
+            int firstInputSize = buffer.readInt();
+            for (int i = 0; i < firstInputSize; i++){
+                ItemStack readStack = buffer.readItem();
+                firstInputList.add(readStack.getItem());
+            }
+            recipe.ingredientList = Lazy.of(() -> firstInputList);
+
             recipe.secondInputAmount = buffer.readInt();
 
             recipe.result = buffer.readItem();
             recipe.processTime = buffer.readInt();
             recipe.outputAmount = buffer.readInt();
             recipe.minimumHeat = buffer.readInt();
+            recipe.ingredientCount = buffer.readInt();
 
             Ingredient tempIngredient = Ingredient.fromNetwork(buffer);
             recipe.ingredient = Lazy.of(() -> tempIngredient);
-
-            recipe.ingredientList = Lazy.of(() -> {
-                ArrayList<Item> temp = new ArrayList<>();
-                for (ItemStack item : recipe.ingredient.get().getItems()) {
-                    temp.add(item.getItem());
-                }
-                return temp;
-            });
 
             // Build Anthology
             recipe.ingredientListIncludingSeconds = RecipeUtil.createLazyAnthology(recipe.ingredientList, recipe.onlySecondInput);
@@ -210,11 +217,30 @@ public class IndustrialBlastingRecipe extends VERecipe {
                 });
             }
 
+            ArrayList<Item> firstInputList = recipe.ingredientList.get();
+            int firstInputSize = firstInputList.size();
+            buffer.writeInt(firstInputSize);
+            for (Item item : firstInputList){
+                buffer.writeItem(
+                        new ItemStack(item,
+                                recipe.ingredientCount > 0
+                                        ? recipe.ingredientCount
+                                        : (recipe.tempIngredientCount.get() > 0 ? recipe.tempIngredientCount.get() : 1)
+                        ));
+            }
+
+
             buffer.writeInt(recipe.secondInputAmount);
             buffer.writeItem(recipe.getResult());
             buffer.writeInt(recipe.processTime);
             buffer.writeInt(recipe.outputAmount);
             buffer.writeInt(recipe.minimumHeat);
+
+            // Ingredient count
+            buffer.writeInt(recipe.ingredientCount > 0
+                    ? recipe.ingredientCount
+                    : (recipe.tempIngredientCount.get() > 0 ? recipe.tempIngredientCount.get() : 1)
+            );
 
             recipe.ingredient.get().toNetwork(buffer);
 

--- a/src/main/java/com/veteam/voluminousenergy/recipe/IndustrialBlastingRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/IndustrialBlastingRecipe.java
@@ -7,7 +7,6 @@ import com.veteam.voluminousenergy.blocks.blocks.VEBlocks;
 import com.veteam.voluminousenergy.util.RecipeUtil;
 import com.veteam.voluminousenergy.util.TagUtil;
 import net.minecraft.network.FriendlyByteBuf;
-import net.minecraft.network.chat.TextComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.GsonHelper;
 import net.minecraft.world.Container;
@@ -22,6 +21,7 @@ import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.ForgeRegistryEntry;
 
 import javax.annotation.Nullable;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -163,7 +163,8 @@ public class IndustrialBlastingRecipe extends VERecipe {
             recipe.usesTagKey = buffer.readBoolean();
 
             if (recipe.usesTagKey){
-                recipe.tagKeyString = buffer.readComponent().getContents();
+                int sequenceLength = buffer.readInt();
+                recipe.tagKeyString = buffer.readCharSequence(sequenceLength, StandardCharsets.UTF_8).toString();
                 ResourceLocation itemTagLocation = new ResourceLocation(recipe.tagKeyString);
                 recipe.onlySecondInput = TagUtil.getLazyItems(itemTagLocation);
 
@@ -205,7 +206,8 @@ public class IndustrialBlastingRecipe extends VERecipe {
         public void toNetwork(FriendlyByteBuf buffer, IndustrialBlastingRecipe recipe){
 
             if (recipe.usesTagKey){
-                buffer.writeComponent(new TextComponent(recipe.tagKeyString));
+                buffer.writeInt(recipe.tagKeyString.length());
+                buffer.writeCharSequence(recipe.tagKeyString, StandardCharsets.UTF_8);
             } else { // does not use tags for item input
                 buffer.writeInt(recipe.ingredientList.get().size());
                 recipe.ingredientList.get().forEach(item -> {

--- a/src/main/java/com/veteam/voluminousenergy/recipe/IndustrialBlastingRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/IndustrialBlastingRecipe.java
@@ -194,7 +194,8 @@ public class IndustrialBlastingRecipe extends VERecipe {
             recipe.outputAmount = buffer.readInt();
             recipe.minimumHeat = buffer.readInt();
 
-            recipe.ingredient = Lazy.of(() -> Ingredient.fromNetwork(buffer));
+            Ingredient tempIngredient = Ingredient.fromNetwork(buffer);
+            recipe.ingredient = Lazy.of(() -> tempIngredient);
 
             // Build Anthology
             recipe.ingredientListIncludingSeconds = RecipeUtil.createLazyAnthology(recipe.ingredientList, recipe.onlySecondInput);

--- a/src/main/java/com/veteam/voluminousenergy/recipe/PrimitiveBlastFurnaceRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/PrimitiveBlastFurnaceRecipe.java
@@ -11,6 +11,7 @@ import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.util.Lazy;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.ForgeRegistryEntry;
 
@@ -23,7 +24,7 @@ public class PrimitiveBlastFurnaceRecipe extends VERecipe {
     public static final Serializer SERIALIZER = new Serializer();
 
     public final ResourceLocation recipeId;
-    public Ingredient ingredient;
+    public Lazy<Ingredient> ingredient;
     public int ingredientCount;
     public ItemStack result;
     private int processTime;
@@ -34,7 +35,7 @@ public class PrimitiveBlastFurnaceRecipe extends VERecipe {
 
     @Override
     public Ingredient getIngredient() {
-        return ingredient;
+        return ingredient.get();
     }
 
     public int getIngredientCount() {
@@ -50,7 +51,7 @@ public class PrimitiveBlastFurnaceRecipe extends VERecipe {
     public boolean matches(Container inv, Level worldIn){
         ItemStack stack = inv.getItem(0);
         int count = stack.getCount();
-        return ingredient.test(stack) && count >= ingredientCount;
+        return ingredient.get().test(stack) && count >= ingredientCount;
     }
 
     @Override
@@ -99,7 +100,7 @@ public class PrimitiveBlastFurnaceRecipe extends VERecipe {
 
             PrimitiveBlastFurnaceRecipe recipe = new PrimitiveBlastFurnaceRecipe(recipeId);
 
-            recipe.ingredient = Ingredient.fromJson(json.get("ingredient"));
+            recipe.ingredient = Lazy.of(() -> Ingredient.fromJson(json.get("ingredient")));
             recipe.ingredientCount = GsonHelper.getAsInt(json.get("ingredient").getAsJsonObject(),"count",1);
             recipe.processTime = GsonHelper.getAsInt(json, "process_time", 200);
 
@@ -120,7 +121,8 @@ public class PrimitiveBlastFurnaceRecipe extends VERecipe {
             recipe.processTime = buffer.readInt();
             recipe.outputAmount = buffer.readInt();
 
-            recipe.ingredient = Ingredient.fromNetwork(buffer);
+            Ingredient tempIngredient = Ingredient.fromNetwork(buffer);
+            recipe.ingredient = Lazy.of(() -> tempIngredient);
 
             return recipe;
         }
@@ -132,7 +134,7 @@ public class PrimitiveBlastFurnaceRecipe extends VERecipe {
             buffer.writeInt(recipe.processTime);
             buffer.writeInt(recipe.outputAmount);
 
-            recipe.ingredient.toNetwork(buffer);
+            recipe.ingredient.get().toNetwork(buffer);
 
         }
     }

--- a/src/main/java/com/veteam/voluminousenergy/recipe/SawmillingRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/SawmillingRecipe.java
@@ -138,7 +138,8 @@ public class SawmillingRecipe extends VERecipe {
             recipe.secondAmount = buffer.readInt();
             recipe.outputFluid = buffer.readFluidStack();
 
-            recipe.ingredient = Lazy.of(() -> Ingredient.fromNetwork(buffer));
+            Ingredient tempIngredient = Ingredient.fromNetwork(buffer);
+            recipe.ingredient = Lazy.of(() -> tempIngredient);
 
             return recipe;
         }

--- a/src/main/java/com/veteam/voluminousenergy/recipe/StirlingGeneratorRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/StirlingGeneratorRecipe.java
@@ -131,7 +131,8 @@ public class StirlingGeneratorRecipe extends VERecipe {
             recipe.energyPerTick = buffer.readInt();
             recipe.result = buffer.readItem();
 
-            recipe.ingredient = Lazy.of(() -> Ingredient.fromNetwork(buffer));
+            Ingredient tempIngredient = Ingredient.fromNetwork(buffer);
+            recipe.ingredient = Lazy.of(() -> tempIngredient);
 
             return recipe;
         }

--- a/src/main/java/com/veteam/voluminousenergy/recipe/ToolingRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/ToolingRecipe.java
@@ -193,7 +193,8 @@ public class ToolingRecipe extends VERecipe {
             recipe.basesAndBits = RecipeUtil.createLazyAnthology(recipe.bases, recipe.bits);
 
             recipe.result = buffer.readItem();
-            recipe.ingredient = Lazy.of(() -> Ingredient.fromNetwork(buffer));
+            Ingredient tempIngredient = Ingredient.fromNetwork(buffer);
+            recipe.ingredient = Lazy.of(() -> tempIngredient);
             return recipe;
         }
 


### PR DESCRIPTION
This PR allows:
* Voluminous Energy to work on 1.18.2 dedicated servers without clients getting kicked
* Recipes to be fully working properly on dedicated servers, and on the clients connected to them