### PR TITLE
Merge JEI Plugin port into 1.18.2-exp

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 mc_version=1.18.2
-jei_version=9.5.0.128
+jei_version=9.5.2.134

--- a/src/main/java/com/veteam/voluminousenergy/blocks/containers/AqueoulizerContainer.java
+++ b/src/main/java/com/veteam/voluminousenergy/blocks/containers/AqueoulizerContainer.java
@@ -24,7 +24,7 @@ import static com.veteam.voluminousenergy.blocks.blocks.VEBlocks.AQUEOULIZER_CON
 public class AqueoulizerContainer extends VoluminousContainer {
 
 
-    public static final int numberOfSlots = 5;
+    public static final int NUMBER_OF_SLOTS = 5;
 
     public AqueoulizerContainer(int id, Level world, BlockPos pos, Inventory inventory, Player player) {
         super(AQUEOULIZER_CONTAINER, id);
@@ -90,7 +90,7 @@ public class AqueoulizerContainer extends VoluminousContainer {
             final ItemStack slotStack = slot.getItem();
             returnStack = slotStack.copy();
 
-            if (handleCoreQuickMoveStackLogicWithUpgradeSlot(index, numberOfSlots, 4, slotStack) != null)
+            if (handleCoreQuickMoveStackLogicWithUpgradeSlot(index, NUMBER_OF_SLOTS, 4, slotStack) != null)
                 return ItemStack.EMPTY;
 
             if (slotStack.getCount() == 0) {

--- a/src/main/java/com/veteam/voluminousenergy/blocks/tiles/AirCompressorTile.java
+++ b/src/main/java/com/veteam/voluminousenergy/blocks/tiles/AirCompressorTile.java
@@ -39,7 +39,7 @@ public class AirCompressorTile extends VEFluidTileEntity implements IVEPoweredTi
 
     public AirCompressorTile(BlockPos pos, BlockState state) {
         super(VEBlocks.AIR_COMPRESSOR_TILE, pos, state);
-        airTank.setValidFluids(Collections.singletonList(CompressedAir.CompressedAirFluid().getFlowing()));
+        airTank.setValidFluids(Collections.singletonList(VEFluids.COMPRESSED_AIR_REG.get()));
     }
 
     @Override

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/VoluminousEnergyPlugin.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/VoluminousEnergyPlugin.java
@@ -2,16 +2,7 @@ package com.veteam.voluminousenergy.compat.jei;
 
 import com.veteam.voluminousenergy.VoluminousEnergy;
 import com.veteam.voluminousenergy.blocks.blocks.VEBlocks;
-import com.veteam.voluminousenergy.blocks.containers.AqueoulizerContainer;
-import com.veteam.voluminousenergy.blocks.containers.BlastFurnaceContainer;
-import com.veteam.voluminousenergy.blocks.containers.CentrifugalSeparatorContainer;
-import com.veteam.voluminousenergy.blocks.containers.CompressorContainer;
-import com.veteam.voluminousenergy.blocks.containers.CrusherContainer;
-import com.veteam.voluminousenergy.blocks.containers.ElectrolyzerContainer;
-import com.veteam.voluminousenergy.blocks.containers.ImplosionCompressorContainer;
-import com.veteam.voluminousenergy.blocks.containers.PrimitiveStirlingGeneratorContainer;
-import com.veteam.voluminousenergy.blocks.containers.StirlingGeneratorContainer;
-import com.veteam.voluminousenergy.blocks.containers.ToolingStationContainer;
+import com.veteam.voluminousenergy.blocks.containers.*;
 import com.veteam.voluminousenergy.blocks.screens.*;
 import com.veteam.voluminousenergy.compat.jei.category.*;
 import com.veteam.voluminousenergy.compat.jei.containerHandler.*;
@@ -21,7 +12,7 @@ import com.veteam.voluminousenergy.recipe.CombustionGenerator.CombustionGenerato
 import com.veteam.voluminousenergy.util.TextUtil;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.JeiPlugin;
-import mezz.jei.api.constants.VanillaRecipeCategoryUid;
+import mezz.jei.api.constants.RecipeTypes;
 import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.helpers.IGuiHelper;
 import mezz.jei.api.registration.*;
@@ -80,18 +71,18 @@ public class VoluminousEnergyPlugin implements IModPlugin {
 
     @Override
     public void registerRecipes(IRecipeRegistration registration){// Add recipes
-        registration.addRecipes(getRecipesOfType(CrusherRecipe.RECIPE_TYPE), CRUSHING_UID);
-        registration.addRecipes(getRecipesOfType(ElectrolyzerRecipe.RECIPE_TYPE), ELECTROLYZING_UID);
-        registration.addRecipes(getRecipesOfType(CompressorRecipe.RECIPE_TYPE), COMPRESSING_UID);
-        registration.addRecipes(getRecipesOfType(CombustionGeneratorFuelRecipe.RECIPE_TYPE), COMBUSTING_UID);
-        registration.addRecipes(getRecipesOfType(StirlingGeneratorRecipe.RECIPE_TYPE), STIRLING_UID);
-        registration.addRecipes(getRecipesOfType(CentrifugalAgitatorRecipe.RECIPE_TYPE), CENTRIFUGAL_AGITATION_UID);
-        registration.addRecipes(getRecipesOfType(AqueoulizerRecipe.RECIPE_TYPE), AQUEOULIZING_UID);
-        registration.addRecipes(getRecipesOfType(DistillationRecipe.RECIPE_TYPE), DISTILLING_UID);
-        registration.addRecipes(getRecipesOfType(CentrifugalSeparatorRecipe.RECIPE_TYPE), CENTRIFUGAL_SEPARATION_UID);
-        registration.addRecipes(getRecipesOfType(ImplosionCompressorRecipe.RECIPE_TYPE), IMPLOSION_COMPRESSION_UID);
-        registration.addRecipes(getRecipesOfType(IndustrialBlastingRecipe.RECIPE_TYPE), INDUSTRIAL_BLASTING_UID);
-        registration.addRecipes(getRecipesOfType(ToolingRecipe.RECIPE_TYPE), TOOLING_UID);
+        registration.addRecipes(CrushingCategory.RECIPE_TYPE, getRecipesOfType(CrusherRecipe.RECIPE_TYPE));
+        registration.addRecipes(ElectrolyzingCategory.RECIPE_TYPE, getRecipesOfType(ElectrolyzerRecipe.RECIPE_TYPE));
+        registration.addRecipes(CompressingCategory.RECIPE_TYPE, getRecipesOfType(CompressorRecipe.RECIPE_TYPE));
+        registration.addRecipes(CombustionCategory.RECIPE_TYPE, getRecipesOfType(CombustionGeneratorFuelRecipe.RECIPE_TYPE));
+        registration.addRecipes(StirlingCategory.RECIPE_TYPE, getRecipesOfType(StirlingGeneratorRecipe.RECIPE_TYPE));
+        registration.addRecipes(CentrifugalAgitationCategory.RECIPE_TYPE, getRecipesOfType(CentrifugalAgitatorRecipe.RECIPE_TYPE));
+        registration.addRecipes(AqueoulizingCategory.RECIPE_TYPE, getRecipesOfType(AqueoulizerRecipe.RECIPE_TYPE));
+        registration.addRecipes(DistillingCategory.RECIPE_TYPE, getRecipesOfType(DistillationRecipe.RECIPE_TYPE));
+        registration.addRecipes(CentrifugalSeparationCategory.RECIPE_TYPE, getRecipesOfType(CentrifugalSeparatorRecipe.RECIPE_TYPE));
+        registration.addRecipes(ImplosionCompressionCategory.RECIPE_TYPE, getRecipesOfType(ImplosionCompressorRecipe.RECIPE_TYPE));
+        registration.addRecipes(IndustrialBlastingCategory.RECIPE_TYPE, getRecipesOfType(IndustrialBlastingRecipe.RECIPE_TYPE));
+        registration.addRecipes(ToolingCategory.RECIPE_TYPE, getRecipesOfType(ToolingRecipe.RECIPE_TYPE));
 
         // Register info for certain ingredients that could use additional explanation for end users
         registerInfo(registration);
@@ -124,7 +115,7 @@ public class VoluminousEnergyPlugin implements IModPlugin {
         registration.addGuiContainerHandler(PrimitiveStirlingGeneratorScreen.class, new PrimitiveStirlingGeneratorContainerHandler());
         registration.addGuiContainerHandler(StirlingGeneratorScreen.class, new StirlingGeneratorContainerHandler());
         registration.addGuiContainerHandler(CentrifugalAgitatorScreen.class, new CentrifugalAgitatorContainerHandler());
-        registration.addRecipeClickArea(AqueoulizerScreen.class, 79, 31, 11, 18, AQUEOULIZING_UID);
+        registration.addRecipeClickArea(AqueoulizerScreen.class, 79, 31, 11, 18, AqueoulizingCategory.RECIPE_TYPE);
         registration.addGuiContainerHandler(AqueoulizerScreen.class, new AqueoulizerContainerHandler());
         registration.addGuiContainerHandler(DistillationUnitScreen.class, new DistillationUnitContainerHandler());
         registration.addGuiContainerHandler(GasFiredFurnaceScreen.class, new GasFiredFurnaceContainerHandler());
@@ -137,36 +128,34 @@ public class VoluminousEnergyPlugin implements IModPlugin {
 
     @Override
     public void registerRecipeTransferHandlers(IRecipeTransferRegistration registration) {
-        registration.addRecipeTransferHandler(CrusherContainer.class, CRUSHING_UID, 0, 1, CrusherContainer.NUMBER_OF_SLOTS, 36);
-        registration.addRecipeTransferHandler(ElectrolyzerContainer.class, ELECTROLYZING_UID, 0, 2, ElectrolyzerContainer.NUMBER_OF_SLOTS, 36);
-        registration.addRecipeTransferHandler(CompressorContainer.class, COMPRESSING_UID, 0, 1, CompressorContainer.NUMBER_OF_SLOTS, 36);
-        registration.addRecipeTransferHandler(PrimitiveStirlingGeneratorContainer.class, STIRLING_UID, 0, 1, PrimitiveStirlingGeneratorContainer.NUMBER_OF_SLOTS, 36);
-        registration.addRecipeTransferHandler(StirlingGeneratorContainer.class, STIRLING_UID, 0, 1, StirlingGeneratorContainer.NUMBER_OF_SLOTS, 36);
-        registration.addRecipeTransferHandler(AqueoulizerContainer.class, AQUEOULIZING_UID, 3, 1, AqueoulizerContainer.numberOfSlots, 36);
-        registration.addRecipeTransferHandler(CentrifugalSeparatorContainer.class, CENTRIFUGAL_SEPARATION_UID, 0, 2, CentrifugalSeparatorContainer.NUMBER_OF_SLOTS, 36);
-        registration.addRecipeTransferHandler(ImplosionCompressorContainer.class, IMPLOSION_COMPRESSION_UID, 0, 2, ImplosionCompressorContainer.NUMBER_OF_SLOTS, 36);
-        registration.addRecipeTransferHandler(BlastFurnaceContainer.class, INDUSTRIAL_BLASTING_UID, 2, 2, BlastFurnaceContainer.NUMBER_OF_SLOTS, 36);
-        registration.addRecipeTransferHandler(ToolingStationContainer.class, TOOLING_UID, 3, 2, ToolingStationContainer.NUMBER_OF_SLOTS, 36);
+        registration.addRecipeTransferHandler(CrusherContainer.class, CrushingCategory.RECIPE_TYPE, 0, 1, CrusherContainer.NUMBER_OF_SLOTS, 36);
+        registration.addRecipeTransferHandler(ElectrolyzerContainer.class, ElectrolyzingCategory.RECIPE_TYPE, 0, 2, ElectrolyzerContainer.NUMBER_OF_SLOTS, 36);
+        registration.addRecipeTransferHandler(CompressorContainer.class, CompressingCategory.RECIPE_TYPE, 0, 1, CompressorContainer.NUMBER_OF_SLOTS, 36);
+        registration.addRecipeTransferHandler(PrimitiveStirlingGeneratorContainer.class, StirlingCategory.RECIPE_TYPE, 0, 1, PrimitiveStirlingGeneratorContainer.NUMBER_OF_SLOTS, 36);
+        registration.addRecipeTransferHandler(StirlingGeneratorContainer.class, StirlingCategory.RECIPE_TYPE, 0, 1, StirlingGeneratorContainer.NUMBER_OF_SLOTS, 36);
+        registration.addRecipeTransferHandler(AqueoulizerContainer.class, AqueoulizingCategory.RECIPE_TYPE, 3, 1, AqueoulizerContainer.NUMBER_OF_SLOTS, 36);
+        registration.addRecipeTransferHandler(CentrifugalSeparatorContainer.class, CentrifugalSeparationCategory.RECIPE_TYPE, 0, 2, CentrifugalSeparatorContainer.NUMBER_OF_SLOTS, 36);
+        registration.addRecipeTransferHandler(ImplosionCompressorContainer.class, ImplosionCompressionCategory.RECIPE_TYPE, 0, 2, ImplosionCompressorContainer.NUMBER_OF_SLOTS, 36);
+        registration.addRecipeTransferHandler(BlastFurnaceContainer.class, IndustrialBlastingCategory.RECIPE_TYPE, 2, 2, BlastFurnaceContainer.NUMBER_OF_SLOTS, 36);
+        registration.addRecipeTransferHandler(ToolingStationContainer.class, ToolingCategory.RECIPE_TYPE, 3, 2, ToolingStationContainer.NUMBER_OF_SLOTS, 36);
     }
 
     @Override
     public void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
-        ResourceLocation combustionLocation = new ResourceLocation(VoluminousEnergy.MODID, "plugin/combusting");
-
-        registration.addRecipeCatalyst(new ItemStack(VEBlocks.CRUSHER_BLOCK).copy(), new ResourceLocation(VoluminousEnergy.MODID, "plugin/crushing"));
-        registration.addRecipeCatalyst(new ItemStack(VEBlocks.ELECTROLYZER_BLOCK).copy(), new ResourceLocation(VoluminousEnergy.MODID, "plugin/electrolyzing"));
-        registration.addRecipeCatalyst(new ItemStack(VEBlocks.COMPRESSOR_BLOCK).copy(), new ResourceLocation(VoluminousEnergy.MODID, "plugin/compressing"));
-        registration.addRecipeCatalyst(new ItemStack(VEBlocks.CENTRIFUGAL_AGITATOR_BLOCK).copy(), new ResourceLocation(VoluminousEnergy.MODID, "plugin/centrifugal_agitation"));
-        registration.addRecipeCatalyst(new ItemStack(VEBlocks.AQUEOULIZER_BLOCK).copy(), new ResourceLocation(VoluminousEnergy.MODID, "plugin/aqueoulizing"));
-        registration.addRecipeCatalyst(new ItemStack(VEBlocks.STIRLING_GENERATOR_BLOCK).copy(), new ResourceLocation(VoluminousEnergy.MODID, "plugin/stirling"));
-        registration.addRecipeCatalyst(new ItemStack(VEBlocks.PRIMITIVE_STIRLING_GENERATOR_BLOCK).copy(), new ResourceLocation(VoluminousEnergy.MODID, "plugin/stirling"));
-        registration.addRecipeCatalyst(new ItemStack(VEBlocks.COMBUSTION_GENERATOR_BLOCK).copy(), combustionLocation);
-        registration.addRecipeCatalyst(new ItemStack(VEBlocks.DISTILLATION_UNIT_BLOCK).copy(), new ResourceLocation(VoluminousEnergy.MODID, "plugin/distilling"));
-        registration.addRecipeCatalyst(new ItemStack(VEBlocks.GAS_FIRED_FURNACE_BLOCK).copy(), VanillaRecipeCategoryUid.FURNACE, VanillaRecipeCategoryUid.BLASTING, combustionLocation);
-        registration.addRecipeCatalyst(new ItemStack(VEBlocks.ELECTRIC_FURNACE_BLOCK).copy(), VanillaRecipeCategoryUid.FURNACE, VanillaRecipeCategoryUid.BLASTING);
-        registration.addRecipeCatalyst(new ItemStack(VEBlocks.CENTRIFUGAL_SEPARATOR_BLOCK).copy(), new ResourceLocation(VoluminousEnergy.MODID, "plugin/centrifugal_separation"));
-        registration.addRecipeCatalyst(new ItemStack(VEBlocks.IMPLOSION_COMPRESSOR_BLOCK).copy(), new ResourceLocation(VoluminousEnergy.MODID, "plugin/implosion_compressing"));
-        registration.addRecipeCatalyst(new ItemStack(VEBlocks.BLAST_FURNACE_BLOCK).copy(), new ResourceLocation(VoluminousEnergy.MODID, "plugin/industrial_blasting"));
-        registration.addRecipeCatalyst(new ItemStack(VEBlocks.TOOLING_STATION_BLOCK).copy(), new ResourceLocation(VoluminousEnergy.MODID, "plugin/tooling"), combustionLocation);
+        registration.addRecipeCatalyst(new ItemStack(VEBlocks.CRUSHER_BLOCK).copy(), CrushingCategory.RECIPE_TYPE);
+        registration.addRecipeCatalyst(new ItemStack(VEBlocks.ELECTROLYZER_BLOCK).copy(), ElectrolyzingCategory.RECIPE_TYPE);
+        registration.addRecipeCatalyst(new ItemStack(VEBlocks.COMPRESSOR_BLOCK).copy(),CompressingCategory.RECIPE_TYPE);
+        registration.addRecipeCatalyst(new ItemStack(VEBlocks.CENTRIFUGAL_AGITATOR_BLOCK).copy(), CentrifugalAgitationCategory.RECIPE_TYPE);
+        registration.addRecipeCatalyst(new ItemStack(VEBlocks.AQUEOULIZER_BLOCK).copy(), AqueoulizingCategory.RECIPE_TYPE);
+        registration.addRecipeCatalyst(new ItemStack(VEBlocks.STIRLING_GENERATOR_BLOCK).copy(), StirlingCategory.RECIPE_TYPE);
+        registration.addRecipeCatalyst(new ItemStack(VEBlocks.PRIMITIVE_STIRLING_GENERATOR_BLOCK).copy(), StirlingCategory.RECIPE_TYPE);
+        registration.addRecipeCatalyst(new ItemStack(VEBlocks.COMBUSTION_GENERATOR_BLOCK).copy(), CombustionCategory.RECIPE_TYPE);
+        registration.addRecipeCatalyst(new ItemStack(VEBlocks.DISTILLATION_UNIT_BLOCK).copy(), DistillingCategory.RECIPE_TYPE);
+        registration.addRecipeCatalyst(new ItemStack(VEBlocks.GAS_FIRED_FURNACE_BLOCK).copy(), RecipeTypes.SMELTING, RecipeTypes.BLASTING, CombustionCategory.RECIPE_TYPE);
+        registration.addRecipeCatalyst(new ItemStack(VEBlocks.ELECTRIC_FURNACE_BLOCK).copy(), RecipeTypes.SMELTING, RecipeTypes.BLASTING);
+        registration.addRecipeCatalyst(new ItemStack(VEBlocks.CENTRIFUGAL_SEPARATOR_BLOCK).copy(), CentrifugalSeparationCategory.RECIPE_TYPE);
+        registration.addRecipeCatalyst(new ItemStack(VEBlocks.IMPLOSION_COMPRESSOR_BLOCK).copy(), ImplosionCompressionCategory.RECIPE_TYPE);
+        registration.addRecipeCatalyst(new ItemStack(VEBlocks.BLAST_FURNACE_BLOCK).copy(), IndustrialBlastingCategory.RECIPE_TYPE);
+        registration.addRecipeCatalyst(new ItemStack(VEBlocks.TOOLING_STATION_BLOCK).copy(), ToolingCategory.RECIPE_TYPE, CombustionCategory.RECIPE_TYPE);
     }
 }

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/category/AqueoulizingCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/category/AqueoulizingCategory.java
@@ -7,22 +7,25 @@ import com.veteam.voluminousenergy.compat.jei.VoluminousEnergyPlugin;
 import com.veteam.voluminousenergy.recipe.AqueoulizerRecipe;
 import com.veteam.voluminousenergy.util.TextUtil;
 import mezz.jei.api.constants.VanillaTypes;
-import mezz.jei.api.gui.IRecipeLayout;
+import mezz.jei.api.gui.builder.IIngredientAcceptor;
+import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
+import mezz.jei.api.gui.builder.IRecipeSlotBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.gui.drawable.IDrawableAnimated;
-import mezz.jei.api.gui.ingredient.IGuiFluidStackGroup;
-import mezz.jei.api.gui.ingredient.IGuiItemStackGroup;
+import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
 import mezz.jei.api.helpers.IGuiHelper;
-import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.recipe.IFocusGroup;
+import mezz.jei.api.recipe.RecipeIngredientRole;
+import mezz.jei.api.recipe.RecipeType;
 import mezz.jei.api.recipe.category.IRecipeCategory;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 public class AqueoulizingCategory implements IRecipeCategory<AqueoulizerRecipe> {
@@ -36,17 +39,24 @@ public class AqueoulizingCategory implements IRecipeCategory<AqueoulizerRecipe> 
         // 68, 12 | 40, 65 -> 10 px added for chance
         ResourceLocation GUI = new ResourceLocation(VoluminousEnergy.MODID, "textures/gui/jei/jei.png");
         background = guiHelper.drawableBuilder(GUI, 68, 12, 90, 40).build();
-        icon = guiHelper.createDrawableIngredient(new ItemStack(VEBlocks.AQUEOULIZER_BLOCK));
+        icon = guiHelper.createDrawableIngredient(VanillaTypes.ITEM, new ItemStack(VEBlocks.AQUEOULIZER_BLOCK));
         slotDrawable = guiHelper.getSlotDrawable();
         arrow = guiHelper.drawableBuilder(GUI, 176, 0, 23, 17).build();
         emptyArrow = guiHelper.drawableBuilder(GUI,199,0,23,17).buildAnimated(200, IDrawableAnimated.StartDirection.LEFT, true);
     }
 
     @Override
-    public ResourceLocation getUid(){
+    public @NotNull RecipeType getRecipeType(){
+        return new RecipeType(VoluminousEnergyPlugin.AQUEOULIZING_UID,AqueoulizerRecipe.class);
+    }
+
+    @Deprecated
+    @Override
+    public ResourceLocation getUid() {
         return VoluminousEnergyPlugin.AQUEOULIZING_UID;
     }
 
+    @Deprecated
     @Override
     public Class<? extends AqueoulizerRecipe> getRecipeClass() {
         return AqueoulizerRecipe.class;
@@ -68,7 +78,7 @@ public class AqueoulizingCategory implements IRecipeCategory<AqueoulizerRecipe> 
     }
 
     @Override
-    public void draw(AqueoulizerRecipe recipe, PoseStack matrixStack, double mouseX, double mouseY) {
+    public void draw(AqueoulizerRecipe recipe, IRecipeSlotsView recipeSlotsView, PoseStack matrixStack, double mouseX, double mouseY) {
         arrow.draw(matrixStack,48, 12);
         emptyArrow.draw(matrixStack,48,12);
         slotDrawable.draw(matrixStack,2,10);
@@ -80,48 +90,47 @@ public class AqueoulizingCategory implements IRecipeCategory<AqueoulizerRecipe> 
         Minecraft.getInstance().font.draw(matrixStack,recipe.getOutputAmount() + "", 72, 32,0x606060);
     }
 
-    @Override
-    public void setIngredients(AqueoulizerRecipe recipe, IIngredients ingredients) {
+
+
+    // NOTE: Needs to be recipe specific; refactoring of setIngredients, which is no longer used
+    public void ingredientHandler(AqueoulizerRecipe recipe,
+                                  IIngredientAcceptor itemInputAcceptor,
+                                  IIngredientAcceptor fluidInputAcceptor,
+                                  IIngredientAcceptor fluidOutputAcceptor) {
 
         // INPUT
         List<ItemStack> inputList = new ArrayList<>();
         for (ItemStack testStack : recipe.getIngredient().getItems()){
-            testStack.setCount(64);
+            testStack.setCount(recipe.getIngredientCount());
             inputList.add(testStack);
         }
-        ingredients.setInputs(VanillaTypes.ITEM, inputList);
+        itemInputAcceptor.addIngredients(VanillaTypes.ITEM, inputList);
 
-        ingredients.setInputs(VanillaTypes.FLUID, recipe.fluidInputList.get());
+        fluidInputAcceptor.addIngredients(VanillaTypes.FLUID, recipe.fluidInputList.get());
 
         // OUTPUT
         List<FluidStack> outputStacks = new ArrayList<>();
         outputStacks.add(recipe.getOutputFluid()); // Normal output
-        ingredients.setOutputs(VanillaTypes.FLUID, outputStacks);
+        fluidOutputAcceptor.addIngredients(VanillaTypes.FLUID, outputStacks);
     }
 
     @Override
-    public void setRecipe(IRecipeLayout recipeLayout, AqueoulizerRecipe recipe, IIngredients ingredients) {
-        IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
-        IGuiFluidStackGroup fluidStacks = recipeLayout.getFluidStacks();
+    public void setRecipe(IRecipeLayoutBuilder recipeLayout, AqueoulizerRecipe recipe, IFocusGroup focusGroup) {
 
-        itemStacks.init(0, true, 2, 10);
-        fluidStacks.init(1, true, 25, 11);
-        fluidStacks.init(2, false, 73,11);
+        // init
+        // Inputs
+        IRecipeSlotBuilder itemInput = recipeLayout.addSlot(RecipeIngredientRole.INPUT, 3, 11); // Coords reused from old init call
+        IRecipeSlotBuilder fluidInput = recipeLayout.addSlot(RecipeIngredientRole.INPUT, 25, 11);
 
-        // Input
+        // Outputs
+        IRecipeSlotBuilder fluidOutput = recipeLayout.addSlot(RecipeIngredientRole.OUTPUT, 73, 11);
 
-        // Should only be one ingredient...
-        List<ItemStack> inputs = new ArrayList<>();
-        Arrays.stream(recipe.getIngredient().getItems()).map(s -> {
-            ItemStack stack = s.copy();
-            stack.setCount(recipe.getIngredientCount());
-            return stack;
-        }).forEach(inputs::add);
-        itemStacks.set(0, inputs);
+        // Setup
+        // Inputs
+        itemInput.setSlotName(TextUtil.TRANSLATED_INPUT_SLOT.getString());
+        this.ingredientHandler(recipe, itemInput, fluidInput, fluidOutput);
 
-        fluidStacks.set(1, recipe.fluidInputList.get());
-
-        // Calculate output
-        fluidStacks.set(2, recipe.getOutputFluid());
+        fluidInput.setSlotName(TextUtil.TRANSLATED_INPUT_TANK.getString());
+        fluidOutput.setSlotName(TextUtil.TRANSLATED_OUTPUT_TANK.getString());
     }
 }

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/category/AqueoulizingCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/category/AqueoulizingCategory.java
@@ -3,6 +3,7 @@ package com.veteam.voluminousenergy.compat.jei.category;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.veteam.voluminousenergy.VoluminousEnergy;
 import com.veteam.voluminousenergy.blocks.blocks.VEBlocks;
+import com.veteam.voluminousenergy.blocks.screens.VEContainerScreen;
 import com.veteam.voluminousenergy.compat.jei.VoluminousEnergyPlugin;
 import com.veteam.voluminousenergy.recipe.AqueoulizerRecipe;
 import com.veteam.voluminousenergy.util.TextUtil;
@@ -85,9 +86,9 @@ public class AqueoulizingCategory implements IRecipeCategory<AqueoulizerRecipe> 
         slotDrawable.draw(matrixStack,24,10);
         slotDrawable.draw(matrixStack,72,10);
 
-        Minecraft.getInstance().font.draw(matrixStack,"mB:", 2, 32,0x606060);
-        Minecraft.getInstance().font.draw(matrixStack,recipe.getInputAmount() + "", 24, 32,0x606060);
-        Minecraft.getInstance().font.draw(matrixStack,recipe.getOutputAmount() + "", 72, 32,0x606060);
+        Minecraft.getInstance().font.draw(matrixStack,"mB:", 2, 32, VEContainerScreen.GREY_TEXT_COLOUR);
+        Minecraft.getInstance().font.draw(matrixStack,recipe.getInputAmount() + "", 24, 32,VEContainerScreen.GREY_TEXT_COLOUR);
+        Minecraft.getInstance().font.draw(matrixStack,recipe.getOutputAmount() + "", 72, 32,VEContainerScreen.GREY_TEXT_COLOUR);
     }
 
 

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/category/AqueoulizingCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/category/AqueoulizingCategory.java
@@ -35,6 +35,7 @@ public class AqueoulizingCategory implements IRecipeCategory<AqueoulizerRecipe> 
     private IDrawable slotDrawable;
     private IDrawable arrow;
     private IDrawable emptyArrow;
+    public static final RecipeType RECIPE_TYPE = new RecipeType(VoluminousEnergyPlugin.AQUEOULIZING_UID,AqueoulizerRecipe.class);
 
     public AqueoulizingCategory(IGuiHelper guiHelper){
         // 68, 12 | 40, 65 -> 10 px added for chance
@@ -48,7 +49,7 @@ public class AqueoulizingCategory implements IRecipeCategory<AqueoulizerRecipe> 
 
     @Override
     public @NotNull RecipeType getRecipeType(){
-        return new RecipeType(VoluminousEnergyPlugin.AQUEOULIZING_UID,AqueoulizerRecipe.class);
+        return RECIPE_TYPE;
     }
 
     @Deprecated

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/category/CentrifugalAgitationCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/category/CentrifugalAgitationCategory.java
@@ -3,25 +3,27 @@ package com.veteam.voluminousenergy.compat.jei.category;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.veteam.voluminousenergy.VoluminousEnergy;
 import com.veteam.voluminousenergy.blocks.blocks.VEBlocks;
+import com.veteam.voluminousenergy.blocks.screens.VEContainerScreen;
 import com.veteam.voluminousenergy.compat.jei.VoluminousEnergyPlugin;
 import com.veteam.voluminousenergy.recipe.CentrifugalAgitatorRecipe;
 import com.veteam.voluminousenergy.util.TextUtil;
 import mezz.jei.api.constants.VanillaTypes;
-import mezz.jei.api.gui.IRecipeLayout;
+import mezz.jei.api.gui.builder.IIngredientAcceptor;
+import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
+import mezz.jei.api.gui.builder.IRecipeSlotBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.gui.drawable.IDrawableAnimated;
-import mezz.jei.api.gui.ingredient.IGuiFluidStackGroup;
+import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
 import mezz.jei.api.helpers.IGuiHelper;
-import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.recipe.IFocusGroup;
+import mezz.jei.api.recipe.RecipeIngredientRole;
+import mezz.jei.api.recipe.RecipeType;
 import mezz.jei.api.recipe.category.IRecipeCategory;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
-import net.minecraftforge.fluids.FluidStack;
-
-import java.util.ArrayList;
-import java.util.List;
+import org.jetbrains.annotations.NotNull;
 
 public class CentrifugalAgitationCategory implements IRecipeCategory<CentrifugalAgitatorRecipe> {
     private final IDrawable background;
@@ -34,17 +36,24 @@ public class CentrifugalAgitationCategory implements IRecipeCategory<Centrifugal
         // 68, 12 | 40, 65 -> 10 px added for chance
         ResourceLocation GUI = new ResourceLocation(VoluminousEnergy.MODID, "textures/gui/jei/jei.png");
         background = guiHelper.drawableBuilder(GUI, 68, 12, 90, 40).build();
-        icon = guiHelper.createDrawableIngredient(new ItemStack(VEBlocks.CENTRIFUGAL_AGITATOR_BLOCK));
+        icon = guiHelper.createDrawableIngredient(VanillaTypes.ITEM, new ItemStack(VEBlocks.CENTRIFUGAL_AGITATOR_BLOCK));
         slotDrawable = guiHelper.getSlotDrawable();
         arrow = guiHelper.drawableBuilder(GUI, 176, 0, 23, 17).build();
         emptyArrow = guiHelper.drawableBuilder(GUI,199,0,23,17).buildAnimated(200, IDrawableAnimated.StartDirection.LEFT, true);
     }
 
     @Override
+    public @NotNull RecipeType getRecipeType(){
+        return new RecipeType(VoluminousEnergyPlugin.CENTRIFUGAL_AGITATION_UID, CentrifugalAgitatorRecipe.class);
+    }
+
+    @Deprecated
+    @Override
     public ResourceLocation getUid(){
         return VoluminousEnergyPlugin.CENTRIFUGAL_AGITATION_UID;
     }
 
+    @Deprecated
     @Override
     public Class<? extends CentrifugalAgitatorRecipe> getRecipeClass() {
         return CentrifugalAgitatorRecipe.class;
@@ -66,44 +75,43 @@ public class CentrifugalAgitationCategory implements IRecipeCategory<Centrifugal
     }
 
     @Override
-    public void draw(CentrifugalAgitatorRecipe recipe, PoseStack matrixStack, double mouseX, double mouseY) {
+    public void draw(CentrifugalAgitatorRecipe recipe, IRecipeSlotsView recipeSlotsView, PoseStack matrixStack, double mouseX, double mouseY) {
         arrow.draw(matrixStack,24, 12);
         emptyArrow.draw(matrixStack,24,12);
         slotDrawable.draw(matrixStack,2,10);
         slotDrawable.draw(matrixStack,48,10);
         slotDrawable.draw(matrixStack,72,10);
 
-        Minecraft.getInstance().font.draw(matrixStack,"mB:", -20,32, 0x606060);
-        Minecraft.getInstance().font.draw(matrixStack,recipe.getInputAmount() + "", 2, 32,0x606060);
-        Minecraft.getInstance().font.draw(matrixStack,recipe.getOutputAmount() + "", 48, 32,0x606060);
-        Minecraft.getInstance().font.draw(matrixStack,recipe.getSecondAmount() + "", 72, 32,0x606060);
+        Minecraft.getInstance().font.draw(matrixStack,"mB:", -20,32, VEContainerScreen.GREY_TEXT_COLOUR);
+        Minecraft.getInstance().font.draw(matrixStack,recipe.getInputAmount() + "", 2, 32,VEContainerScreen.GREY_TEXT_COLOUR);
+        Minecraft.getInstance().font.draw(matrixStack,recipe.getOutputAmount() + "", 48, 32,VEContainerScreen.GREY_TEXT_COLOUR);
+        Minecraft.getInstance().font.draw(matrixStack,recipe.getSecondAmount() + "", 72, 32,VEContainerScreen.GREY_TEXT_COLOUR);
+    }
+
+    public void ingredientHandler(CentrifugalAgitatorRecipe recipe,
+                                  IIngredientAcceptor fluidInputAcceptor,
+                                  IIngredientAcceptor firstFluidOutputAcceptor,
+                                  IIngredientAcceptor secondFluidOutputAcceptor) {
+
+        fluidInputAcceptor.addIngredients(VanillaTypes.FLUID, recipe.fluidInputList.get());
+
+        firstFluidOutputAcceptor.addIngredient(VanillaTypes.FLUID, recipe.getOutputFluid());
+        secondFluidOutputAcceptor.addIngredient(VanillaTypes.FLUID, recipe.getSecondFluid());
     }
 
     @Override
-    public void setIngredients(CentrifugalAgitatorRecipe recipe, IIngredients ingredients) {
-
-        // INPUT
-        ingredients.setInputs(VanillaTypes.FLUID, recipe.fluidInputList.get());
-
-        // OUTPUT
-        List<FluidStack> outputStacks = new ArrayList<>();
-        outputStacks.add(recipe.getOutputFluid()); // Normal output
-        outputStacks.add(recipe.getSecondFluid()); // Second output
-        ingredients.setOutputs(VanillaTypes.FLUID, outputStacks);
-    }
-
-    @Override
-    public void setRecipe(IRecipeLayout recipeLayout, CentrifugalAgitatorRecipe recipe, IIngredients ingredients) {
-        IGuiFluidStackGroup fluidStacks = recipeLayout.getFluidStacks();
-        fluidStacks.init(0, true, 3, 11);
-        fluidStacks.init(1, false, 49, 11);
-        fluidStacks.init(2, false, 73,11);
-
+    public void setRecipe(IRecipeLayoutBuilder recipeLayout, CentrifugalAgitatorRecipe recipe, IFocusGroup focusGroup) {
         // Input
-        fluidStacks.set(0, recipe.fluidInputList.get());
+        IRecipeSlotBuilder fluidInput = recipeLayout.addSlot(RecipeIngredientRole.INPUT, 3, 11);
 
-        // Calculate output
-        fluidStacks.set(1, recipe.getOutputFluid());
-        fluidStacks.set(2, recipe.getSecondFluid());
+        // Output
+        IRecipeSlotBuilder firstFluidOutput = recipeLayout.addSlot(RecipeIngredientRole.OUTPUT, 49, 11);
+        IRecipeSlotBuilder secondFluidOutput = recipeLayout.addSlot(RecipeIngredientRole.OUTPUT, 73, 11);
+
+        fluidInput.setSlotName(TextUtil.TRANSLATED_INPUT_TANK.getString());
+        firstFluidOutput.setSlotName(TextUtil.TRANSLATED_OUTPUT_TANK.getString());
+        secondFluidOutput.setSlotName(TextUtil.TRANSLATED_OUTPUT_TANK.getString());
+
+        this.ingredientHandler(recipe, fluidInput, firstFluidOutput, secondFluidOutput);
     }
 }

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/category/CentrifugalAgitationCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/category/CentrifugalAgitationCategory.java
@@ -31,6 +31,7 @@ public class CentrifugalAgitationCategory implements IRecipeCategory<Centrifugal
     private IDrawable slotDrawable;
     private IDrawable arrow;
     private IDrawable emptyArrow;
+    public static final RecipeType RECIPE_TYPE = new RecipeType(VoluminousEnergyPlugin.CENTRIFUGAL_AGITATION_UID, CentrifugalAgitatorRecipe.class);
 
     public CentrifugalAgitationCategory(IGuiHelper guiHelper){
         // 68, 12 | 40, 65 -> 10 px added for chance
@@ -44,7 +45,7 @@ public class CentrifugalAgitationCategory implements IRecipeCategory<Centrifugal
 
     @Override
     public @NotNull RecipeType getRecipeType(){
-        return new RecipeType(VoluminousEnergyPlugin.CENTRIFUGAL_AGITATION_UID, CentrifugalAgitatorRecipe.class);
+        return RECIPE_TYPE;
     }
 
     @Deprecated

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/category/CentrifugalSeparationCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/category/CentrifugalSeparationCategory.java
@@ -34,6 +34,7 @@ public class CentrifugalSeparationCategory implements IRecipeCategory<Centrifuga
     private IDrawable slotDrawable;
     private IDrawable arrow;
     private IDrawable emptyArrow;
+    public static final RecipeType RECIPE_TYPE = new RecipeType(VoluminousEnergyPlugin.CENTRIFUGAL_SEPARATION_UID, CentrifugalSeparatorRecipe.class);
 
     public CentrifugalSeparationCategory(IGuiHelper guiHelper){
         // 68, 12 | 40, 65 -> 10 px added for chance
@@ -48,7 +49,7 @@ public class CentrifugalSeparationCategory implements IRecipeCategory<Centrifuga
 
     @Override
     public @NotNull RecipeType getRecipeType(){
-        return new RecipeType(VoluminousEnergyPlugin.CENTRIFUGAL_SEPARATION_UID, CentrifugalSeparatorRecipe.class);
+        return RECIPE_TYPE;
     }
 
     @Deprecated

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/category/CentrifugalSeparationCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/category/CentrifugalSeparationCategory.java
@@ -3,28 +3,30 @@ package com.veteam.voluminousenergy.compat.jei.category;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.veteam.voluminousenergy.VoluminousEnergy;
 import com.veteam.voluminousenergy.blocks.blocks.VEBlocks;
+import com.veteam.voluminousenergy.blocks.screens.VEContainerScreen;
 import com.veteam.voluminousenergy.compat.jei.VoluminousEnergyPlugin;
 import com.veteam.voluminousenergy.recipe.CentrifugalSeparatorRecipe;
 import com.veteam.voluminousenergy.util.TextUtil;
 import mezz.jei.api.constants.VanillaTypes;
-import mezz.jei.api.gui.IRecipeLayout;
+import mezz.jei.api.gui.builder.IIngredientAcceptor;
+import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
+import mezz.jei.api.gui.builder.IRecipeSlotBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.gui.drawable.IDrawableAnimated;
-import mezz.jei.api.gui.ingredient.IGuiItemStackGroup;
+import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
 import mezz.jei.api.helpers.IGuiHelper;
-import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.recipe.IFocusGroup;
+import mezz.jei.api.recipe.RecipeIngredientRole;
+import mezz.jei.api.recipe.RecipeType;
 import mezz.jei.api.recipe.category.IRecipeCategory;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class CentrifugalSeparationCategory implements IRecipeCategory<CentrifugalSeparatorRecipe> {
     private final IDrawable background;
@@ -37,7 +39,7 @@ public class CentrifugalSeparationCategory implements IRecipeCategory<Centrifuga
         // 68, 12 | 40, 65 -> 10 px added for chance
         ResourceLocation GUI = new ResourceLocation(VoluminousEnergy.MODID, "textures/gui/jei/jei.png");
         background = guiHelper.drawableBuilder(GUI, 52, 5, 120, 78).build();
-        icon = guiHelper.createDrawableIngredient(new ItemStack(VEBlocks.CENTRIFUGAL_SEPARATOR_BLOCK));
+        icon = guiHelper.createDrawableIngredient(VanillaTypes.ITEM, new ItemStack(VEBlocks.CENTRIFUGAL_SEPARATOR_BLOCK));
         slotDrawable = guiHelper.getSlotDrawable();
         arrow = guiHelper.drawableBuilder(GUI, 176, 0, 23, 17).build();
         emptyArrow = guiHelper.drawableBuilder(GUI,199,0,23,17).buildAnimated(200, IDrawableAnimated.StartDirection.LEFT, true);
@@ -45,10 +47,17 @@ public class CentrifugalSeparationCategory implements IRecipeCategory<Centrifuga
     }
 
     @Override
+    public @NotNull RecipeType getRecipeType(){
+        return new RecipeType(VoluminousEnergyPlugin.CENTRIFUGAL_SEPARATION_UID, CentrifugalSeparatorRecipe.class);
+    }
+
+    @Deprecated
+    @Override
     public ResourceLocation getUid(){
         return VoluminousEnergyPlugin.CENTRIFUGAL_SEPARATION_UID;
     }
 
+    @Deprecated
     @Override
     public Class<? extends CentrifugalSeparatorRecipe> getRecipeClass() {
         return CentrifugalSeparatorRecipe.class;
@@ -70,7 +79,7 @@ public class CentrifugalSeparationCategory implements IRecipeCategory<Centrifuga
     }
 
     @Override
-    public void draw(CentrifugalSeparatorRecipe recipe, PoseStack matrixStack, double mouseX, double mouseY) {
+    public void draw(CentrifugalSeparatorRecipe recipe, IRecipeSlotsView recipeSlotsView, PoseStack matrixStack, double mouseX, double mouseY) {
         arrow.draw(matrixStack,25, 30);
         emptyArrow.draw(matrixStack,25,30);
         slotDrawable.draw(matrixStack,5,20); // Input
@@ -82,104 +91,81 @@ public class CentrifugalSeparationCategory implements IRecipeCategory<Centrifuga
 
         if (recipe.getRngItemSlot0() != null && recipe.getRngItemSlot0().getItem() != Items.AIR){
             int chance = (int)(recipe.getChance0()*100);
-            Minecraft.getInstance().font.draw(matrixStack,chance + "%",74,26,0x606060);
+            Minecraft.getInstance().font.draw(matrixStack,chance + "%",74,26, VEContainerScreen.GREY_TEXT_COLOUR);
         }
 
         if (recipe.getRngItemSlot1() != null && recipe.getRngItemSlot1().getItem() != Items.AIR){
             int chance = (int)(recipe.getChance1()*100);
-            Minecraft.getInstance().font.draw(matrixStack,chance + "%",74,44,0x606060);
+            Minecraft.getInstance().font.draw(matrixStack,chance + "%",74,44,VEContainerScreen.GREY_TEXT_COLOUR);
         }
 
         if (recipe.getRngItemSlot2() != null && recipe.getRngItemSlot2().getItem() != Items.AIR){
             int chance = (int)(recipe.getChance2()*100);
-            Minecraft.getInstance().font.draw(matrixStack,chance + "%",74,62,0x606060);
+            Minecraft.getInstance().font.draw(matrixStack,chance + "%",74,62,VEContainerScreen.GREY_TEXT_COLOUR);
         }
 
     }
 
-    @Override
-    public void setIngredients(CentrifugalSeparatorRecipe recipe, IIngredients ingredients) {
-        ingredients.setInputLists(VanillaTypes.ITEM, recipe.getIngredientMap().keySet().stream()
-                .map(ingredient -> Arrays.asList(ingredient.getItems()))
-                .collect(Collectors.toList()));
+    public void ingredientHandler(CentrifugalSeparatorRecipe recipe,
+                               IIngredientAcceptor itemInputAcceptor,
+                               IIngredientAcceptor bucketInputAcceptor,
+                               IIngredientAcceptor primaryOutputAcceptor,
+                               IIngredientAcceptor rng0OutputAcceptor,
+                               IIngredientAcceptor rng1OutputAcceptor,
+                               IIngredientAcceptor rng2OutputAcceptor) {
 
-
-        // STACK needs to be 64 for recipes that require more than 1 of the input item
-        // This for loop ensures that every input can be right clicked, maybe it can just fetch the current ingredient
-        // to save CPU cycles... but this works.
-        for (ItemStack testStack : recipe.getIngredient().getItems()){
-            testStack.setCount(64);
-            ingredients.setInput(VanillaTypes.ITEM, testStack);
+        // Input
+        ArrayList<ItemStack> inputStacks = new ArrayList<>();
+        for (ItemStack itemStack : recipe.ingredient.get().getItems()){
+            itemStack.setCount(recipe.ingredientCount);
+            inputStacks.add(itemStack);
         }
 
-        // OUTPUT
-        List<ItemStack> outputStacks = new ArrayList<>();
-        outputStacks.add(recipe.getResultItem()); // Normal output
-
-        if (recipe.getRngItemSlot0() != null && recipe.getRngItemSlot0().getItem() != Items.AIR){ // Check RNG 0 if it's not air
-            outputStacks.add(recipe.getRngItemSlot0());
-        }
-
-        if (recipe.getRngItemSlot1() != null && recipe.getRngItemSlot1().getItem() != Items.AIR){ // Check RNG 1 if it's not air
-            outputStacks.add(recipe.getRngItemSlot1());
-        }
-
-        if (recipe.getRngItemSlot2() != null && recipe.getRngItemSlot2().getItem() != Items.AIR){ // Check RNG 2 if it's not air
-            outputStacks.add(recipe.getRngItemSlot2());
-        }
-
-        ingredients.setOutputs(VanillaTypes.ITEM, outputStacks);
-    }
-
-    @Override
-    public void setRecipe(IRecipeLayout recipeLayout, CentrifugalSeparatorRecipe recipe, IIngredients ingredients) {
-        IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
-        itemStacks.init(0, true, 5, 20);
-        itemStacks.init(1, false, 49, 2);
-
-        // Should only be one ingredient...
-        List<ItemStack> inputs = new ArrayList<>();
-        Arrays.stream(recipe.getIngredient().getItems()).map(s -> {
-            ItemStack stack = s.copy();
-            stack.setCount(recipe.getIngredientCount());
-            return stack;
-        }).forEach(inputs::add);
-        itemStacks.set(0, inputs);
-
-        // Calculate output
-        ItemStack tempStack = recipe.getResultItem(); // Get Item since amount will be wrong
-        Item outputItem = tempStack.getItem();
-        ItemStack jeiStack = new ItemStack(outputItem, recipe.getOutputAmount()); // Create new stack for JEI with correct amount
-        itemStacks.set(1, jeiStack);
-
-        // Calculate RNG stack, only if RNG stack exists
-        if (recipe.getRngItemSlot0() != null && recipe.getRngItemSlot0().getItem() != Items.AIR){ // Don't create the slot if the slot will be empty!
-            itemStacks.init(2, false, 49, 20);
-            tempStack = recipe.getRngItemSlot0();
-            Item rngItem = tempStack.getItem();
-            ItemStack rngStack = new ItemStack(rngItem, recipe.getOutputRngAmount0());
-            itemStacks.set(2, rngStack);
-        }
-
-        if (recipe.getRngItemSlot1() != null && recipe.getRngItemSlot1().getItem() != Items.AIR){ // Don't create the slot if the slot will be empty!
-            itemStacks.init(3, false, 49, 38);
-            tempStack = recipe.getRngItemSlot1();
-            Item rngItem = tempStack.getItem();
-            ItemStack rngStack = new ItemStack(rngItem, recipe.getOutputRngAmount1());
-            itemStacks.set(3, rngStack);
-        }
-
-        if (recipe.getRngItemSlot2() != null && recipe.getRngItemSlot2().getItem() != Items.AIR){ // Don't create the slot if the slot will be empty!
-            itemStacks.init(4, false, 49, 56);
-            tempStack = recipe.getRngItemSlot2();
-            Item rngItem = tempStack.getItem();
-            ItemStack rngStack = new ItemStack(rngItem, recipe.getOutputRngAmount2());
-            itemStacks.set(4, rngStack);
-        }
+        itemInputAcceptor.addIngredients(VanillaTypes.ITEM, inputStacks);
 
         if (recipe.needsBuckets() > 0){
-            itemStacks.init(5, true, 5, 38);
-            itemStacks.set(5, new ItemStack(Items.BUCKET, recipe.needsBuckets()));
+            ItemStack bucketStack = new ItemStack(Items.BUCKET, recipe.needsBuckets());
+            bucketInputAcceptor.addIngredient(VanillaTypes.ITEM, bucketStack);
         }
+
+        // Output --> ItemStacks here are not guaranteed to have correct amount; must do so manually
+        ItemStack primaryOutputStack = recipe.result.copy();
+        primaryOutputStack.setCount(recipe.getOutputAmount());
+        primaryOutputAcceptor.addIngredient(VanillaTypes.ITEM, primaryOutputStack);
+
+        ItemStack rng0 = recipe.getRngItemSlot0().copy();
+        rng0.setCount(recipe.getOutputRngAmount0());
+        rng0OutputAcceptor.addIngredient(VanillaTypes.ITEM, rng0);
+
+        ItemStack rng1 = recipe.getRngItemSlot1().copy();
+        rng1.setCount(recipe.getOutputRngAmount1());
+        rng1OutputAcceptor.addIngredient(VanillaTypes.ITEM, rng1);
+
+        ItemStack rng2 = recipe.getRngItemSlot2().copy();
+        rng2.setCount(recipe.getOutputRngAmount2());
+        rng2OutputAcceptor.addIngredient(VanillaTypes.ITEM, rng2);
+    }
+
+    @Override
+    public void setRecipe(IRecipeLayoutBuilder recipeLayout, CentrifugalSeparatorRecipe recipe, IFocusGroup focusGroup) {
+        // Inputs
+        IRecipeSlotBuilder itemInput = recipeLayout.addSlot(RecipeIngredientRole.INPUT,6,21);
+        IRecipeSlotBuilder bucketInput = recipeLayout.addSlot(RecipeIngredientRole.INPUT,6, 39);
+
+        // Outputs
+        IRecipeSlotBuilder firstOutput = recipeLayout.addSlot(RecipeIngredientRole.OUTPUT, 50,3);
+        IRecipeSlotBuilder secondOutput = recipeLayout.addSlot(RecipeIngredientRole.OUTPUT, 50, 21); // RNG 1
+        IRecipeSlotBuilder thirdOutput = recipeLayout.addSlot(RecipeIngredientRole.OUTPUT, 50, 39); // RNG 2
+        IRecipeSlotBuilder fourthOutput = recipeLayout.addSlot(RecipeIngredientRole.OUTPUT, 50, 57); // RNG 3
+
+        itemInput.setSlotName(TextUtil.TRANSLATED_INPUT_SLOT.getString());
+        bucketInput.setSlotName(TextUtil.TRANSLATED_BUCKET_SLOT.getString());
+
+        firstOutput.setSlotName(TextUtil.TRANSLATED_OUTPUT_SLOT.getString());
+        secondOutput.setSlotName(TextUtil.TRANSLATED_RNG_SLOT.getString());
+        thirdOutput.setSlotName(TextUtil.TRANSLATED_RNG_SLOT.getString());
+        fourthOutput.setSlotName(TextUtil.TRANSLATED_RNG_SLOT.getString());
+
+        this.ingredientHandler(recipe, itemInput, bucketInput, firstOutput, secondOutput, thirdOutput, fourthOutput);
     }
 }

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/category/CombustionCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/category/CombustionCategory.java
@@ -38,6 +38,7 @@ public class CombustionCategory implements IRecipeCategory<CombustionGeneratorFu
     private final IDrawable background;
     private IDrawable icon;
     private IDrawable slotDrawable;
+    public static final RecipeType RECIPE_TYPE = new RecipeType(VoluminousEnergyPlugin.COMBUSTING_UID, CombustionGeneratorFuelRecipe.class);
 
     public CombustionCategory(IGuiHelper guiHelper){
         // 68, 12 | 40, 65 -> 10 px added for chance
@@ -49,7 +50,7 @@ public class CombustionCategory implements IRecipeCategory<CombustionGeneratorFu
 
     @Override
     public @NotNull RecipeType getRecipeType(){
-        return new RecipeType(VoluminousEnergyPlugin.COMBUSTING_UID, CombustionGeneratorFuelRecipe.class);
+        return RECIPE_TYPE;
     }
 
     @Deprecated

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/category/CombustionCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/category/CombustionCategory.java
@@ -19,6 +19,7 @@ import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
 import mezz.jei.api.helpers.IGuiHelper;
 import mezz.jei.api.recipe.IFocusGroup;
 import mezz.jei.api.recipe.RecipeIngredientRole;
+import mezz.jei.api.recipe.RecipeType;
 import mezz.jei.api.recipe.category.IRecipeCategory;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
@@ -27,6 +28,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraftforge.fluids.FluidStack;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.Optional;
@@ -40,16 +42,23 @@ public class CombustionCategory implements IRecipeCategory<CombustionGeneratorFu
     public CombustionCategory(IGuiHelper guiHelper){
         // 68, 12 | 40, 65 -> 10 px added for chance
         ResourceLocation GUI = new ResourceLocation(VoluminousEnergy.MODID, "textures/gui/jei/combustion_generator.png");
-        background = guiHelper.drawableBuilder(GUI, 52, 5, 120, 78).build();
+        background = guiHelper.drawableBuilder(GUI, 52, 5, 120, 64).build();
         icon = guiHelper.createDrawableIngredient(VanillaTypes.ITEM, new ItemStack(VEBlocks.COMBUSTION_GENERATOR_BLOCK));
         slotDrawable = guiHelper.getSlotDrawable();
     }
 
     @Override
+    public @NotNull RecipeType getRecipeType(){
+        return new RecipeType(VoluminousEnergyPlugin.COMBUSTING_UID, CombustionGeneratorFuelRecipe.class);
+    }
+
+    @Deprecated
+    @Override
     public ResourceLocation getUid(){
         return VoluminousEnergyPlugin.COMBUSTING_UID;
     }
 
+    @Deprecated
     @Override
     public Class<? extends CombustionGeneratorFuelRecipe> getRecipeClass() {
         return CombustionGeneratorFuelRecipe.class;
@@ -73,11 +82,26 @@ public class CombustionCategory implements IRecipeCategory<CombustionGeneratorFu
     @Override
     public void draw(CombustionGeneratorFuelRecipe recipe, IRecipeSlotsView slotsView, PoseStack matrixStack, double mouseX, double mouseY){
 
-        Minecraft.getInstance().font.draw(matrixStack,"Volumetric Energy: ",31,4, VEContainerScreen.GREY_TEXT_COLOUR);
-        Minecraft.getInstance().font.draw(matrixStack,recipe.getVolumetricEnergy() + " FE",42,16, VEContainerScreen.GREY_TEXT_COLOUR);
-        slotDrawable.draw(matrixStack,11,0); // Volumetric Energy
-        slotDrawable.draw(matrixStack, 11, 35); // Fuel fluid
-        slotDrawable.draw(matrixStack, 95, 35); // Oxidizer fluid
+        // Volumetric Energy label
+        Minecraft.getInstance().font.drawShadow(
+                matrixStack,
+                TextUtil.translateString("jei.voluminousenergy.volumetric_energy").copy().append(": "),
+                16,
+                4,
+                VEContainerScreen.WHITE_TEXT_COLOUR
+        );
+
+        // Actual Volumetric Energy value + FE/B units added on the end
+        Minecraft.getInstance().font.draw(
+                matrixStack,
+                recipe.getVolumetricEnergy() + " FE/B",
+                35,
+                16,
+                VEContainerScreen.GREY_TEXT_COLOUR
+        );
+
+        slotDrawable.draw(matrixStack, 17, 35); // Fuel fluid
+        slotDrawable.draw(matrixStack, 85, 35); // Oxidizer fluid
 
         Optional<FluidStack> oxiStack = slotsView.getSlotViews(RecipeIngredientRole.CATALYST).get(0).getDisplayedIngredient(VanillaTypes.FLUID);
 
@@ -89,19 +113,34 @@ public class CombustionCategory implements IRecipeCategory<CombustionGeneratorFu
             int x = 50;
             if (fePerTick < 100){
                 x = 54;
-            } else if (fePerTick > 999){
+            } else if (fePerTick > 999 && fePerTick < 10_000){
                 x = 46;
             } else if (fePerTick > 9999){
                 NumberUtil.numberToTextComponent4FE(fePerTick);
+                x = 46;
             }
 
-            Minecraft.getInstance().font.drawShadow(matrixStack, fePerTickComponent, x, 44,VEContainerScreen.WHITE_TEXT_COLOUR);
+            Minecraft.getInstance().font.draw(matrixStack, fePerTickComponent, x, 45,VEContainerScreen.GREY_TEXT_COLOUR);
         }
 
-        Minecraft.getInstance().font.drawShadow(matrixStack,"FE/t:",48,36,VEContainerScreen.WHITE_TEXT_COLOUR);
+        Minecraft.getInstance().font.drawShadow(matrixStack,"FE/t:",48,35,VEContainerScreen.WHITE_TEXT_COLOUR);
 
-        Minecraft.getInstance().font.draw(matrixStack, "Fuel:", 10, 26, VEContainerScreen.GREY_TEXT_COLOUR);
-        Minecraft.getInstance().font.draw(matrixStack, "Oxidizer:", 88,26, VEContainerScreen.GREY_TEXT_COLOUR);
+        Minecraft.getInstance().font.draw(
+                matrixStack,
+                TextUtil.translateString("jei.voluminousenergy.fluid.fuel").copy().append(":"),
+                16,
+                26,
+                VEContainerScreen.GREY_TEXT_COLOUR
+        );
+
+        // Oxidizer Label
+        Minecraft.getInstance().font.draw(
+                matrixStack,
+                TextUtil.translateString("jei.voluminousenergy.fluid.oxidizer").copy().append(":"),
+                76,
+                26,
+                VEContainerScreen.GREY_TEXT_COLOUR
+        );
 
     }
 
@@ -131,8 +170,8 @@ public class CombustionCategory implements IRecipeCategory<CombustionGeneratorFu
     @Override
     public void setRecipe(IRecipeLayoutBuilder recipeLayout, CombustionGeneratorFuelRecipe recipe, IFocusGroup focusGroup) {
         // Init
-        IRecipeSlotBuilder fuel = recipeLayout.addSlot(RecipeIngredientRole.INPUT, 12, 36);
-        IRecipeSlotBuilder oxidizer = recipeLayout.addSlot(RecipeIngredientRole.CATALYST, 96, 36);
+        IRecipeSlotBuilder fuel = recipeLayout.addSlot(RecipeIngredientRole.INPUT, 18, 36);
+        IRecipeSlotBuilder oxidizer = recipeLayout.addSlot(RecipeIngredientRole.CATALYST, 86, 36);
 
         this.ingredientHandler(recipe, fuel, oxidizer);
     }

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/category/CompressingCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/category/CompressingCategory.java
@@ -24,8 +24,6 @@ import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.concurrent.atomic.AtomicReference;
 
 public class CompressingCategory implements IRecipeCategory<CompressorRecipe> {
 
@@ -90,13 +88,13 @@ public class CompressingCategory implements IRecipeCategory<CompressorRecipe> {
                                   IIngredientAcceptor itemOutputAcceptor) {
 
         // Input
-        AtomicReference<ArrayList<ItemStack>> atomicInputStack = new AtomicReference<>(new ArrayList<>());
-        Arrays.stream(recipe.ingredient.get().getItems()).forEach(itemStack -> {
-         itemStack.setCount(recipe.getIngredientCount());
-         atomicInputStack.get().add(itemStack);
-        });
+        ArrayList<ItemStack> inputStacks = new ArrayList<>();
+        for (ItemStack itemStack : recipe.ingredient.get().getItems()){
+            itemStack.setCount(recipe.ingredientCount);
+            inputStacks.add(itemStack);
+        }
 
-        itemInputAcceptor.addIngredients(VanillaTypes.ITEM, atomicInputStack.get());
+        itemInputAcceptor.addIngredients(VanillaTypes.ITEM, inputStacks);
 
         // Output
         ItemStack outputStack = recipe.result;

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/category/CompressingCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/category/CompressingCategory.java
@@ -32,6 +32,7 @@ public class CompressingCategory implements IRecipeCategory<CompressorRecipe> {
     private IDrawable slotDrawable;
     private IDrawable arrow;
     private IDrawable emptyArrow;
+    public static final RecipeType RECIPE_TYPE = new RecipeType(VoluminousEnergyPlugin.COMPRESSING_UID, CompressorRecipe.class);
 
     public CompressingCategory(IGuiHelper guiHelper){
         // 68, 12 | 40, 65 -> 10 px added for chance
@@ -45,7 +46,7 @@ public class CompressingCategory implements IRecipeCategory<CompressorRecipe> {
 
     @Override
     public @NotNull RecipeType getRecipeType(){
-        return new RecipeType(VoluminousEnergyPlugin.COMPRESSING_UID, CompressorRecipe.class);
+        return RECIPE_TYPE;
     }
 
     @Deprecated

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/category/CompressingCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/category/CompressingCategory.java
@@ -97,7 +97,7 @@ public class CompressingCategory implements IRecipeCategory<CompressorRecipe> {
         itemInputAcceptor.addIngredients(VanillaTypes.ITEM, inputStacks);
 
         // Output
-        ItemStack outputStack = recipe.result;
+        ItemStack outputStack = recipe.result.copy();
         outputStack.setCount(recipe.getOutputAmount());
 
         itemOutputAcceptor.addIngredient(VanillaTypes.ITEM, outputStack);

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/category/CompressingCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/category/CompressingCategory.java
@@ -108,10 +108,10 @@ public class CompressingCategory implements IRecipeCategory<CompressorRecipe> {
     @Override
     public void setRecipe(IRecipeLayoutBuilder recipeLayout, CompressorRecipe recipe, IFocusGroup focusGroup) {
         // Inputs
-        IRecipeSlotBuilder itemInput = recipeLayout.addSlot(RecipeIngredientRole.INPUT, 2, 10);
+        IRecipeSlotBuilder itemInput = recipeLayout.addSlot(RecipeIngredientRole.INPUT, 3, 11);
 
         // Output
-        IRecipeSlotBuilder itemOutput = recipeLayout.addSlot(RecipeIngredientRole.OUTPUT, 48, 10);
+        IRecipeSlotBuilder itemOutput = recipeLayout.addSlot(RecipeIngredientRole.OUTPUT, 49, 11);
 
         itemInput.setSlotName(TextUtil.TRANSLATED_INPUT_SLOT.getString());
         itemOutput.setSlotName(TextUtil.TRANSLATED_OUTPUT_SLOT.getString());

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/category/CrushingCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/category/CrushingCategory.java
@@ -35,6 +35,7 @@ public class CrushingCategory implements IRecipeCategory<CrusherRecipe> {
     private IDrawable icon;
     private IDrawable slotDrawable;
     private IDrawable arrow;
+    public static final RecipeType RECIPE_TYPE = new RecipeType(VoluminousEnergyPlugin.CRUSHING_UID, CrusherRecipe.class);
 
     public CrushingCategory(IGuiHelper guiHelper){
         // 68, 12 | 40, 65 -> 10 px added for chance
@@ -46,7 +47,7 @@ public class CrushingCategory implements IRecipeCategory<CrusherRecipe> {
 
     @Override
     public @NotNull RecipeType getRecipeType(){
-        return new RecipeType(VoluminousEnergyPlugin.CRUSHING_UID, CrusherRecipe.class);
+        return RECIPE_TYPE;
     }
 
     @Deprecated

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/category/CrushingCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/category/CrushingCategory.java
@@ -3,27 +3,30 @@ package com.veteam.voluminousenergy.compat.jei.category;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.veteam.voluminousenergy.blocks.blocks.VEBlocks;
 import com.veteam.voluminousenergy.blocks.screens.CrusherScreen;
+import com.veteam.voluminousenergy.blocks.screens.VEContainerScreen;
 import com.veteam.voluminousenergy.compat.jei.VoluminousEnergyPlugin;
 import com.veteam.voluminousenergy.recipe.CrusherRecipe;
 import com.veteam.voluminousenergy.util.TextUtil;
 import mezz.jei.api.constants.VanillaTypes;
-import mezz.jei.api.gui.IRecipeLayout;
+import mezz.jei.api.gui.builder.IIngredientAcceptor;
+import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
+import mezz.jei.api.gui.builder.IRecipeSlotBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.gui.drawable.IDrawableAnimated;
-import mezz.jei.api.gui.ingredient.IGuiItemStackGroup;
+import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
 import mezz.jei.api.helpers.IGuiHelper;
-import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.recipe.IFocusGroup;
+import mezz.jei.api.recipe.RecipeIngredientRole;
+import mezz.jei.api.recipe.RecipeType;
 import mezz.jei.api.recipe.category.IRecipeCategory;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 
 public class CrushingCategory implements IRecipeCategory<CrusherRecipe> {
@@ -35,18 +38,24 @@ public class CrushingCategory implements IRecipeCategory<CrusherRecipe> {
 
     public CrushingCategory(IGuiHelper guiHelper){
         // 68, 12 | 40, 65 -> 10 px added for chance
-        //ResourceLocation GUI = new ResourceLocation(VoluminousEnergy.MODID, "textures/gui/jei/jei.png");
         background = guiHelper.drawableBuilder(CrusherScreen.getGUI(), 68, 12, 40, 70).build();
-        icon = guiHelper.createDrawableIngredient(new ItemStack(VEBlocks.CRUSHER_BLOCK));
+        icon = guiHelper.createDrawableIngredient(VanillaTypes.ITEM, new ItemStack(VEBlocks.CRUSHER_BLOCK));
         slotDrawable = guiHelper.getSlotDrawable();
         arrow = guiHelper.drawableBuilder(CrusherScreen.getGUI(), 176, 0, 17, 24).buildAnimated(200, IDrawableAnimated.StartDirection.TOP, false);
     }
 
     @Override
+    public @NotNull RecipeType getRecipeType(){
+        return new RecipeType(VoluminousEnergyPlugin.CRUSHING_UID, CrusherRecipe.class);
+    }
+
+    @Deprecated
+    @Override
     public ResourceLocation getUid(){
         return VoluminousEnergyPlugin.CRUSHING_UID;
     }
 
+    @Deprecated
     @Override
     public Class<? extends CrusherRecipe> getRecipeClass() {
         return CrusherRecipe.class;
@@ -68,7 +77,7 @@ public class CrushingCategory implements IRecipeCategory<CrusherRecipe> {
     }
 
     @Override
-    public void draw(CrusherRecipe recipe, PoseStack matrixStack, double mouseX, double mouseY) {
+    public void draw(CrusherRecipe recipe, IRecipeSlotsView recipeSlotsView, PoseStack matrixStack, double mouseX, double mouseY) {
         arrow.draw(matrixStack,10, 19);
 
 
@@ -80,63 +89,47 @@ public class CrushingCategory implements IRecipeCategory<CrusherRecipe> {
             } else if (chance < 10){
                 xPos += 5;
             }
-            Minecraft.getInstance().font.draw(matrixStack,chance + "%",xPos,65,0x606060);
+            Minecraft.getInstance().font.draw(matrixStack,chance + "%",xPos,65, VEContainerScreen.GREY_TEXT_COLOUR);
         }
 
     }
 
-    @Override
-    public void setIngredients(CrusherRecipe recipe, IIngredients ingredients) {
-        // STACK needs to be 64 for recipes that require more than 1 of the input item
-        // This for loop ensures that every input can be right clicked, maybe it can just fetch the current ingredient
-        // to save CPU cycles... but this works.
+    public void ingredientHandler(CrusherRecipe recipe,
+                                  IIngredientAcceptor itemInputAcceptor,
+                                  IIngredientAcceptor itemOutputAcceptor,
+                                  IIngredientAcceptor itemRNGOutputAcceptor) {
+        // Input
         ArrayList<ItemStack> inputStacks = new ArrayList<>();
-        for (ItemStack tempStack : recipe.getIngredient().getItems()){
-            tempStack.setCount(64);
-            inputStacks.add(tempStack.copy());
+        for (ItemStack itemStack : recipe.ingredient.get().getItems()){
+            itemStack.setCount(recipe.ingredientCount);
+            inputStacks.add(itemStack);
         }
-        ingredients.setInputs(VanillaTypes.ITEM, inputStacks);
+        itemInputAcceptor.addIngredients(VanillaTypes.ITEM, inputStacks);
 
-        // OUTPUT
-        List<ItemStack> outputStacks = new ArrayList<>();
-        outputStacks.add(recipe.getResultItem()); // Normal output
+        // Output
+        ItemStack resultStack = recipe.result;
+        resultStack.setCount(recipe.getOutputAmount());
+        itemOutputAcceptor.addIngredient(VanillaTypes.ITEM, resultStack);
 
-        if (recipe.getRngItem() != null && recipe.getRngItem().getItem() != Items.AIR){ // Check RNG if it's not air
-            outputStacks.add(recipe.getRngItem());
-        }
-
-        ingredients.setOutputs(VanillaTypes.ITEM, outputStacks);
+        ItemStack rngStack = recipe.rngResult;
+        rngStack.setCount(recipe.getOutputRngAmount());
+        itemRNGOutputAcceptor.addIngredient(VanillaTypes.ITEM, rngStack);
     }
 
     @Override
-    public void setRecipe(IRecipeLayout recipeLayout, CrusherRecipe recipe, IIngredients ingredients) {
-        IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
-        itemStacks.init(0, true, 11, 0);
-        itemStacks.init(1, false, 2, 45);
+    public void setRecipe(IRecipeLayoutBuilder recipeLayout, CrusherRecipe recipe, IFocusGroup focusGroup) {
+        // Input
+        IRecipeSlotBuilder itemInput = recipeLayout.addSlot(RecipeIngredientRole.INPUT, 12, 1);
 
-        // Should only be one ingredient...
-        List<ItemStack> inputs = new ArrayList<>();
-        Arrays.stream(recipe.getIngredient().getItems()).map(s -> {
-            ItemStack stack = s.copy();
-            stack.setCount(recipe.getIngredientCount());
-            return stack;
-        }).forEach(inputs::add);
-        itemStacks.set(0, inputs);
+        // Output
+        IRecipeSlotBuilder primaryItemOutput = recipeLayout.addSlot(RecipeIngredientRole.OUTPUT, 3, 46);
+        IRecipeSlotBuilder rngItemOutput = recipeLayout.addSlot(RecipeIngredientRole.OUTPUT,  21, 46);
 
-        // Calculate output
-        ItemStack tempStack = recipe.getResultItem(); // Get Item since amount will be wrong
-        Item outputItem = tempStack.getItem();
-        ItemStack jeiStack = new ItemStack(outputItem, recipe.getOutputAmount()); // Create new stack for JEI with correct amount
-        itemStacks.set(1, jeiStack);
+        itemInput.setSlotName(TextUtil.TRANSLATED_INPUT_SLOT.getString());
+        primaryItemOutput.setSlotName(TextUtil.TRANSLATED_OUTPUT_SLOT.getString());
+        rngItemOutput.setSlotName(TextUtil.TRANSLATED_RNG_SLOT.getString());
 
-        // Calculate RNG stack, only if RNG stack exists
-        if (recipe.getRngItem() != null && recipe.getRngItem().getItem() != Items.AIR){ // Don't create the slot if the slot will be empty!
-            itemStacks.init(2, false, 20, 45);
-            tempStack = recipe.getRngItem();
-            Item rngItem = tempStack.getItem();
-            ItemStack rngStack = new ItemStack(rngItem, recipe.getOutputRngAmount());
-            itemStacks.set(2, rngStack);
-        }
+        this.ingredientHandler(recipe, itemInput, primaryItemOutput, rngItemOutput);
     }
 
 }

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/category/CrushingCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/category/CrushingCategory.java
@@ -107,11 +107,11 @@ public class CrushingCategory implements IRecipeCategory<CrusherRecipe> {
         itemInputAcceptor.addIngredients(VanillaTypes.ITEM, inputStacks);
 
         // Output
-        ItemStack resultStack = recipe.result;
+        ItemStack resultStack = recipe.result.copy();
         resultStack.setCount(recipe.getOutputAmount());
         itemOutputAcceptor.addIngredient(VanillaTypes.ITEM, resultStack);
 
-        ItemStack rngStack = recipe.rngResult;
+        ItemStack rngStack = recipe.rngResult.copy();
         rngStack.setCount(recipe.getOutputRngAmount());
         itemRNGOutputAcceptor.addIngredient(VanillaTypes.ITEM, rngStack);
     }

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/category/DistillingCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/category/DistillingCategory.java
@@ -3,26 +3,27 @@ package com.veteam.voluminousenergy.compat.jei.category;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.veteam.voluminousenergy.VoluminousEnergy;
 import com.veteam.voluminousenergy.blocks.blocks.VEBlocks;
+import com.veteam.voluminousenergy.blocks.screens.VEContainerScreen;
 import com.veteam.voluminousenergy.compat.jei.VoluminousEnergyPlugin;
 import com.veteam.voluminousenergy.recipe.DistillationRecipe;
 import com.veteam.voluminousenergy.util.TextUtil;
 import mezz.jei.api.constants.VanillaTypes;
-import mezz.jei.api.gui.IRecipeLayout;
+import mezz.jei.api.gui.builder.IIngredientAcceptor;
+import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
+import mezz.jei.api.gui.builder.IRecipeSlotBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.gui.drawable.IDrawableAnimated;
-import mezz.jei.api.gui.ingredient.IGuiFluidStackGroup;
-import mezz.jei.api.gui.ingredient.IGuiItemStackGroup;
+import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
 import mezz.jei.api.helpers.IGuiHelper;
-import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.recipe.IFocusGroup;
+import mezz.jei.api.recipe.RecipeIngredientRole;
+import mezz.jei.api.recipe.RecipeType;
 import mezz.jei.api.recipe.category.IRecipeCategory;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
-import net.minecraftforge.fluids.FluidStack;
-
-import java.util.ArrayList;
-import java.util.List;
+import org.jetbrains.annotations.NotNull;
 
 public class DistillingCategory implements IRecipeCategory<DistillationRecipe> {
     private final IDrawable background;
@@ -35,17 +36,24 @@ public class DistillingCategory implements IRecipeCategory<DistillationRecipe> {
         // 68, 12 | 40, 65 -> 10 px added for chance
         ResourceLocation GUI = new ResourceLocation(VoluminousEnergy.MODID, "textures/gui/jei/jei.png");
         background = guiHelper.drawableBuilder(GUI, 42, 5, 128, 40).build();
-        icon = guiHelper.createDrawableIngredient(new ItemStack(VEBlocks.DISTILLATION_UNIT_BLOCK));
+        icon = guiHelper.createDrawableIngredient(VanillaTypes.ITEM, new ItemStack(VEBlocks.DISTILLATION_UNIT_BLOCK));
         slotDrawable = guiHelper.getSlotDrawable();
         arrow = guiHelper.drawableBuilder(GUI, 176, 0, 23, 17).build();
         emptyArrow = guiHelper.drawableBuilder(GUI,199,0,23,17).buildAnimated(200, IDrawableAnimated.StartDirection.LEFT, true);
     }
 
     @Override
+    public @NotNull RecipeType getRecipeType(){
+        return new RecipeType(VoluminousEnergyPlugin.DISTILLING_UID, DistillationRecipe.class);
+    }
+
+    @Deprecated
+    @Override
     public ResourceLocation getUid(){
         return VoluminousEnergyPlugin.DISTILLING_UID;
     }
 
+    @Deprecated
     @Override
     public Class<? extends DistillationRecipe> getRecipeClass() {
         return DistillationRecipe.class;
@@ -67,7 +75,7 @@ public class DistillingCategory implements IRecipeCategory<DistillationRecipe> {
     }
 
     @Override
-    public void draw(DistillationRecipe recipe, PoseStack matrixStack, double mouseX, double mouseY) {
+    public void draw(DistillationRecipe recipe, IRecipeSlotsView recipeSlotsView, PoseStack matrixStack, double mouseX, double mouseY) {
         arrow.draw(matrixStack,24, 12);
         emptyArrow.draw(matrixStack,24,12);
         slotDrawable.draw(matrixStack,2,10);
@@ -75,42 +83,44 @@ public class DistillingCategory implements IRecipeCategory<DistillationRecipe> {
         slotDrawable.draw(matrixStack,72,10);
         slotDrawable.draw(matrixStack,96,10);
 
-        Minecraft.getInstance().font.draw(matrixStack,"mB:", -20,32, 0x606060);
-        Minecraft.getInstance().font.draw(matrixStack,recipe.getInputAmount() + "", 2, 32,0x606060);
-        Minecraft.getInstance().font.draw(matrixStack,recipe.getOutputAmount() + "", 48, 32,0x606060);
-        Minecraft.getInstance().font.draw(matrixStack,recipe.getAmounts().get(2) + "", 72, 32,0x606060);
+        Minecraft.getInstance().font.draw(matrixStack,"mB:", -20,32, VEContainerScreen.GREY_TEXT_COLOUR);
+        Minecraft.getInstance().font.draw(matrixStack,recipe.getInputAmount() + "", 2, 32,VEContainerScreen.GREY_TEXT_COLOUR);
+        Minecraft.getInstance().font.draw(matrixStack,recipe.getOutputAmount() + "", 48, 32,VEContainerScreen.GREY_TEXT_COLOUR);
+        Minecraft.getInstance().font.draw(matrixStack,recipe.getAmounts().get(2) + "", 72, 32,VEContainerScreen.GREY_TEXT_COLOUR);
     }
 
-    @Override
-    public void setIngredients(DistillationRecipe recipe, IIngredients ingredients) {
-        // INPUT
-        ingredients.setInputs(VanillaTypes.FLUID, recipe.fluidInputList.get());
-
-        // OUTPUT
-        List<FluidStack> outputStacks = new ArrayList<>();
-        outputStacks.add(recipe.getOutputFluid()); // Normal output
-        outputStacks.add(recipe.getSecondFluid());
-
-        ingredients.setOutputs(VanillaTypes.FLUID, outputStacks);
-        ingredients.setOutput(VanillaTypes.ITEM, recipe.getThirdResult());
-    }
-
-    @Override
-    public void setRecipe(IRecipeLayout recipeLayout, DistillationRecipe recipe, IIngredients ingredients) {
-        IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
-        IGuiFluidStackGroup fluidStacks = recipeLayout.getFluidStacks();
-
-        fluidStacks.init(0, true, 3,11);
-        fluidStacks.init(1, false, 49,11);
-        fluidStacks.init(2, false, 73,11);
-        itemStacks.init(3,false, 96,10);
-
+    public void ingredientHandler(DistillationRecipe recipe,
+                                  IIngredientAcceptor fluidInputAcceptor,
+                                  IIngredientAcceptor firstFluidOutputAcceptor,
+                                  IIngredientAcceptor secondFluidOutputAcceptor,
+                                  IIngredientAcceptor itemOutputAcceptor) {
         // Input
-        fluidStacks.set(0, recipe.fluidInputList.get());
+        fluidInputAcceptor.addIngredients(VanillaTypes.FLUID, recipe.fluidInputList.get());
 
-        // Calculate output
-        fluidStacks.set(1, recipe.getOutputFluid());
-        fluidStacks.set(2, recipe.getSecondFluid());
-        itemStacks.set(3, recipe.getThirdResult());
+        // Output
+        firstFluidOutputAcceptor.addIngredient(VanillaTypes.FLUID, recipe.getOutputFluid()); // seems like amount is set correctly
+        secondFluidOutputAcceptor.addIngredient(VanillaTypes.FLUID, recipe.getSecondFluid()); // seems like amount is set correctly
+
+        ItemStack itemStackResult = recipe.getThirdResult();
+        itemStackResult.setCount(recipe.getThirdAmount());
+        itemOutputAcceptor.addIngredient(VanillaTypes.ITEM,itemStackResult);
+    }
+
+    @Override
+    public void setRecipe(IRecipeLayoutBuilder recipeLayout, DistillationRecipe recipe, IFocusGroup focusGroup) {
+        // Inputs
+        IRecipeSlotBuilder fluidInput = recipeLayout.addSlot(RecipeIngredientRole.INPUT, 3, 11);
+
+        // Outputs
+        IRecipeSlotBuilder firstFluidOutput = recipeLayout.addSlot(RecipeIngredientRole.OUTPUT, 49, 11);
+        IRecipeSlotBuilder secondFluidOutput = recipeLayout.addSlot(RecipeIngredientRole.OUTPUT, 73, 11);
+        IRecipeSlotBuilder itemOutput = recipeLayout.addSlot(RecipeIngredientRole.OUTPUT, 97, 11);
+
+        fluidInput.setSlotName(TextUtil.TRANSLATED_INPUT_TANK.getString());
+        firstFluidOutput.setSlotName(TextUtil.TRANSLATED_OUTPUT_TANK.getString());
+        secondFluidOutput.setSlotName(TextUtil.TRANSLATED_OUTPUT_TANK.getString());
+        itemOutput.setSlotName(TextUtil.TRANSLATED_OUTPUT_SLOT.getString());
+
+        this.ingredientHandler(recipe, fluidInput, firstFluidOutput, secondFluidOutput, itemOutput);
     }
 }

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/category/DistillingCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/category/DistillingCategory.java
@@ -31,6 +31,7 @@ public class DistillingCategory implements IRecipeCategory<DistillationRecipe> {
     private IDrawable slotDrawable;
     private IDrawable arrow;
     private IDrawable emptyArrow;
+    public static final RecipeType RECIPE_TYPE = new RecipeType(VoluminousEnergyPlugin.DISTILLING_UID, DistillationRecipe.class);
 
     public DistillingCategory(IGuiHelper guiHelper){
         // 68, 12 | 40, 65 -> 10 px added for chance
@@ -44,7 +45,7 @@ public class DistillingCategory implements IRecipeCategory<DistillationRecipe> {
 
     @Override
     public @NotNull RecipeType getRecipeType(){
-        return new RecipeType(VoluminousEnergyPlugin.DISTILLING_UID, DistillationRecipe.class);
+        return RECIPE_TYPE;
     }
 
     @Deprecated

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/category/DistillingCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/category/DistillingCategory.java
@@ -101,7 +101,7 @@ public class DistillingCategory implements IRecipeCategory<DistillationRecipe> {
         firstFluidOutputAcceptor.addIngredient(VanillaTypes.FLUID, recipe.getOutputFluid()); // seems like amount is set correctly
         secondFluidOutputAcceptor.addIngredient(VanillaTypes.FLUID, recipe.getSecondFluid()); // seems like amount is set correctly
 
-        ItemStack itemStackResult = recipe.getThirdResult();
+        ItemStack itemStackResult = recipe.getThirdResult().copy();
         itemStackResult.setCount(recipe.getThirdAmount());
         itemOutputAcceptor.addIngredient(VanillaTypes.ITEM,itemStackResult);
     }

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/category/ElectrolyzingCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/category/ElectrolyzingCategory.java
@@ -35,6 +35,7 @@ public class ElectrolyzingCategory implements IRecipeCategory<ElectrolyzerRecipe
     private IDrawable slotDrawable;
     private IDrawable arrow;
     private IDrawable emptyArrow;
+    public static final RecipeType RECIPE_TYPE = new RecipeType(VoluminousEnergyPlugin.ELECTROLYZING_UID, ElectrolyzerRecipe.class);
 
     public ElectrolyzingCategory(IGuiHelper guiHelper){
         // 68, 12 | 40, 65 -> 10 px added for chance
@@ -49,7 +50,7 @@ public class ElectrolyzingCategory implements IRecipeCategory<ElectrolyzerRecipe
 
     @Override
     public @NotNull RecipeType getRecipeType(){
-        return new RecipeType(VoluminousEnergyPlugin.ELECTROLYZING_UID, ElectrolyzerRecipe.class);
+        return RECIPE_TYPE;
     }
 
     @Deprecated

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/category/ElectrolyzingCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/category/ElectrolyzingCategory.java
@@ -3,28 +3,30 @@ package com.veteam.voluminousenergy.compat.jei.category;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.veteam.voluminousenergy.VoluminousEnergy;
 import com.veteam.voluminousenergy.blocks.blocks.VEBlocks;
+import com.veteam.voluminousenergy.blocks.screens.VEContainerScreen;
 import com.veteam.voluminousenergy.compat.jei.VoluminousEnergyPlugin;
 import com.veteam.voluminousenergy.recipe.ElectrolyzerRecipe;
 import com.veteam.voluminousenergy.util.TextUtil;
 import mezz.jei.api.constants.VanillaTypes;
-import mezz.jei.api.gui.IRecipeLayout;
+import mezz.jei.api.gui.builder.IIngredientAcceptor;
+import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
+import mezz.jei.api.gui.builder.IRecipeSlotBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.gui.drawable.IDrawableAnimated;
-import mezz.jei.api.gui.ingredient.IGuiItemStackGroup;
+import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
 import mezz.jei.api.helpers.IGuiHelper;
-import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.recipe.IFocusGroup;
+import mezz.jei.api.recipe.RecipeIngredientRole;
+import mezz.jei.api.recipe.RecipeType;
 import mezz.jei.api.recipe.category.IRecipeCategory;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class ElectrolyzingCategory implements IRecipeCategory<ElectrolyzerRecipe> {
 
@@ -38,7 +40,7 @@ public class ElectrolyzingCategory implements IRecipeCategory<ElectrolyzerRecipe
         // 68, 12 | 40, 65 -> 10 px added for chance
         ResourceLocation GUI = new ResourceLocation(VoluminousEnergy.MODID, "textures/gui/jei/jei.png");
         background = guiHelper.drawableBuilder(GUI, 52, 5, 120, 78).build();
-        icon = guiHelper.createDrawableIngredient(new ItemStack(VEBlocks.ELECTROLYZER_BLOCK));
+        icon = guiHelper.createDrawableIngredient(VanillaTypes.ITEM, new ItemStack(VEBlocks.ELECTROLYZER_BLOCK));
         slotDrawable = guiHelper.getSlotDrawable();
         arrow = guiHelper.drawableBuilder(GUI, 176, 0, 23, 17).build();
         emptyArrow = guiHelper.drawableBuilder(GUI,199,0,23,17).buildAnimated(200, IDrawableAnimated.StartDirection.LEFT, true);
@@ -46,10 +48,17 @@ public class ElectrolyzingCategory implements IRecipeCategory<ElectrolyzerRecipe
     }
 
     @Override
+    public @NotNull RecipeType getRecipeType(){
+        return new RecipeType(VoluminousEnergyPlugin.ELECTROLYZING_UID, ElectrolyzerRecipe.class);
+    }
+
+    @Deprecated
+    @Override
     public ResourceLocation getUid(){
         return VoluminousEnergyPlugin.ELECTROLYZING_UID;
     }
 
+    @Deprecated
     @Override
     public Class<? extends ElectrolyzerRecipe> getRecipeClass() {
         return ElectrolyzerRecipe.class;
@@ -71,7 +80,7 @@ public class ElectrolyzingCategory implements IRecipeCategory<ElectrolyzerRecipe
     }
 
     @Override
-    public void draw(ElectrolyzerRecipe recipe, PoseStack matrixStack, double mouseX, double mouseY) {
+    public void draw(ElectrolyzerRecipe recipe, IRecipeSlotsView recipeSlotsView, PoseStack matrixStack, double mouseX, double mouseY) {
         arrow.draw(matrixStack,25, 30);
         emptyArrow.draw(matrixStack,25,30);
         slotDrawable.draw(matrixStack,5,20); // Input
@@ -83,104 +92,78 @@ public class ElectrolyzingCategory implements IRecipeCategory<ElectrolyzerRecipe
 
         if (recipe.getRngItemSlot0() != null && recipe.getRngItemSlot0().getItem() != Items.AIR){
             int chance = (int)(recipe.getChance0()*100);
-            Minecraft.getInstance().font.draw(matrixStack,chance + "%",74,26,0x606060);
+            Minecraft.getInstance().font.draw(matrixStack,chance + "%",74,26, VEContainerScreen.GREY_TEXT_COLOUR);
         }
 
         if (recipe.getRngItemSlot1() != null && recipe.getRngItemSlot1().getItem() != Items.AIR){
             int chance = (int)(recipe.getChance1()*100);
-            Minecraft.getInstance().font.draw(matrixStack,chance + "%",74,44,0x606060);
+            Minecraft.getInstance().font.draw(matrixStack,chance + "%",74,44,VEContainerScreen.GREY_TEXT_COLOUR);
         }
 
         if (recipe.getRngItemSlot2() != null && recipe.getRngItemSlot2().getItem() != Items.AIR){
             int chance = (int)(recipe.getChance2()*100);
-            Minecraft.getInstance().font.draw(matrixStack,chance + "%",74,62,0x606060);
+            Minecraft.getInstance().font.draw(matrixStack,chance + "%",74,62,VEContainerScreen.GREY_TEXT_COLOUR);
         }
 
     }
 
-    @Override
-    public void setIngredients(ElectrolyzerRecipe recipe, IIngredients ingredients) {
-        ingredients.setInputLists(VanillaTypes.ITEM, recipe.getIngredientMap().keySet().stream()
-                .map(ingredient -> Arrays.asList(ingredient.getItems()))
-                .collect(Collectors.toList()));
-
-
-        // STACK needs to be 64 for recipes that require more than 1 of the input item
-        // This for loop ensures that every input can be right clicked, maybe it can just fetch the current ingredient
-        // to save CPU cycles... but this works.
-        for (ItemStack testStack : recipe.getIngredient().getItems()){
-            testStack.setCount(64);
-            ingredients.setInput(VanillaTypes.ITEM, testStack);
+    public void ingredientHandler(ElectrolyzerRecipe recipe,
+                                  IIngredientAcceptor itemInputAcceptor,
+                                  IIngredientAcceptor bucketInputAcceptor,
+                                  IIngredientAcceptor primaryOutputAcceptor,
+                                  IIngredientAcceptor rng0OutputAcceptor,
+                                  IIngredientAcceptor rng1OutputAcceptor,
+                                  IIngredientAcceptor rng2OutputAcceptor) {
+        ArrayList<ItemStack> inputStacks = new ArrayList<>();
+        for (ItemStack itemStack : recipe.ingredient.get().getItems()){
+            itemStack.setCount(recipe.ingredientCount);
+            inputStacks.add(itemStack);
         }
 
-        // OUTPUT
-        List<ItemStack> outputStacks = new ArrayList<>();
-        outputStacks.add(recipe.getResultItem()); // Normal output
-
-        if (recipe.getRngItemSlot0() != null && recipe.getRngItemSlot0().getItem() != Items.AIR){ // Check RNG 0 if it's not air
-            outputStacks.add(recipe.getRngItemSlot0());
-        }
-
-        if (recipe.getRngItemSlot1() != null && recipe.getRngItemSlot1().getItem() != Items.AIR){ // Check RNG 1 if it's not air
-            outputStacks.add(recipe.getRngItemSlot1());
-        }
-
-        if (recipe.getRngItemSlot2() != null && recipe.getRngItemSlot2().getItem() != Items.AIR){ // Check RNG 2 if it's not air
-            outputStacks.add(recipe.getRngItemSlot2());
-        }
-
-        ingredients.setOutputs(VanillaTypes.ITEM, outputStacks);
-    }
-
-    @Override
-    public void setRecipe(IRecipeLayout recipeLayout, ElectrolyzerRecipe recipe, IIngredients ingredients) {
-        IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
-        itemStacks.init(0, true, 5, 20);
-        itemStacks.init(1, false, 49, 2);
-
-        // Should only be one ingredient...
-        List<ItemStack> inputs = new ArrayList<>();
-        Arrays.stream(recipe.getIngredient().getItems()).map(s -> {
-            ItemStack stack = s.copy();
-            stack.setCount(recipe.getIngredientCount());
-            return stack;
-        }).forEach(inputs::add);
-        itemStacks.set(0, inputs);
-
-        // Calculate output
-        ItemStack tempStack = recipe.getResultItem(); // Get Item since amount will be wrong
-        Item outputItem = tempStack.getItem();
-        ItemStack jeiStack = new ItemStack(outputItem, recipe.getOutputAmount()); // Create new stack for JEI with correct amount
-        itemStacks.set(1, jeiStack);
-
-        // Calculate RNG stack, only if RNG stack exists
-        if (recipe.getRngItemSlot0() != null && recipe.getRngItemSlot0().getItem() != Items.AIR){ // Don't create the slot if the slot will be empty!
-            itemStacks.init(2, false, 49, 20);
-            tempStack = recipe.getRngItemSlot0();
-            Item rngItem = tempStack.getItem();
-            ItemStack rngStack = new ItemStack(rngItem, recipe.getOutputRngAmount0());
-            itemStacks.set(2, rngStack);
-        }
-
-        if (recipe.getRngItemSlot1() != null && recipe.getRngItemSlot1().getItem() != Items.AIR){ // Don't create the slot if the slot will be empty!
-            itemStacks.init(3, false, 49, 38);
-            tempStack = recipe.getRngItemSlot1();
-            Item rngItem = tempStack.getItem();
-            ItemStack rngStack = new ItemStack(rngItem, recipe.getOutputRngAmount1());
-            itemStacks.set(3, rngStack);
-        }
-
-        if (recipe.getRngItemSlot2() != null && recipe.getRngItemSlot2().getItem() != Items.AIR){ // Don't create the slot if the slot will be empty!
-            itemStacks.init(4, false, 49, 56);
-            tempStack = recipe.getRngItemSlot2();
-            Item rngItem = tempStack.getItem();
-            ItemStack rngStack = new ItemStack(rngItem, recipe.getOutputRngAmount2());
-            itemStacks.set(4, rngStack);
-        }
+        itemInputAcceptor.addIngredients(VanillaTypes.ITEM, inputStacks);
 
         if (recipe.needsBuckets() > 0){
-            itemStacks.init(5, true, 5, 38);
-            itemStacks.set(5, new ItemStack(Items.BUCKET, recipe.needsBuckets()));
+            ItemStack bucketStack = new ItemStack(Items.BUCKET, recipe.needsBuckets());
+            bucketInputAcceptor.addIngredient(VanillaTypes.ITEM, bucketStack);
         }
+
+        // Output --> ItemStacks here are not guaranteed to have correct amount; must do so manually
+        ItemStack primaryOutputStack = recipe.result.copy();
+        primaryOutputStack.setCount(recipe.getOutputAmount());
+        primaryOutputAcceptor.addIngredient(VanillaTypes.ITEM, primaryOutputStack);
+
+        ItemStack rng0 = recipe.getRngItemSlot0().copy();
+        rng0.setCount(recipe.getOutputRngAmount0());
+        rng0OutputAcceptor.addIngredient(VanillaTypes.ITEM, rng0);
+
+        ItemStack rng1 = recipe.getRngItemSlot1().copy();
+        rng1.setCount(recipe.getOutputRngAmount1());
+        rng1OutputAcceptor.addIngredient(VanillaTypes.ITEM, rng1);
+
+        ItemStack rng2 = recipe.getRngItemSlot2().copy();
+        rng2.setCount(recipe.getOutputRngAmount2());
+        rng2OutputAcceptor.addIngredient(VanillaTypes.ITEM, rng2);
+    }
+
+    @Override
+    public void setRecipe(IRecipeLayoutBuilder recipeLayout, ElectrolyzerRecipe recipe, IFocusGroup focusGroup) {
+        // Inputs
+        IRecipeSlotBuilder itemInput = recipeLayout.addSlot(RecipeIngredientRole.INPUT, 6, 21);
+        IRecipeSlotBuilder bucketInput = recipeLayout.addSlot(RecipeIngredientRole.INPUT, 6, 39);
+
+        // Output
+        IRecipeSlotBuilder itemOutput = recipeLayout.addSlot(RecipeIngredientRole.OUTPUT, 50,3);
+        IRecipeSlotBuilder rng0Output = recipeLayout.addSlot(RecipeIngredientRole.OUTPUT, 50,21);
+        IRecipeSlotBuilder rng1Output = recipeLayout.addSlot(RecipeIngredientRole.OUTPUT, 50,39);
+        IRecipeSlotBuilder rng2Output = recipeLayout.addSlot(RecipeIngredientRole.OUTPUT, 50,57);
+
+        itemInput.setSlotName(TextUtil.TRANSLATED_INPUT_SLOT.getString());
+        bucketInput.setSlotName(TextUtil.TRANSLATED_BUCKET_SLOT.getString());
+        itemOutput.setSlotName(TextUtil.TRANSLATED_OUTPUT_SLOT.getString());
+        rng0Output.setSlotName(TextUtil.TRANSLATED_RNG_SLOT.getString());
+        rng1Output.setSlotName(TextUtil.TRANSLATED_RNG_SLOT.getString());
+        rng2Output.setSlotName(TextUtil.TRANSLATED_RNG_SLOT.getString());
+
+        this.ingredientHandler(recipe, itemInput, bucketInput, itemOutput, rng0Output, rng1Output, rng2Output);
     }
 }

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/category/ImplosionCompressionCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/category/ImplosionCompressionCategory.java
@@ -7,23 +7,24 @@ import com.veteam.voluminousenergy.compat.jei.VoluminousEnergyPlugin;
 import com.veteam.voluminousenergy.recipe.ImplosionCompressorRecipe;
 import com.veteam.voluminousenergy.util.TextUtil;
 import mezz.jei.api.constants.VanillaTypes;
-import mezz.jei.api.gui.IRecipeLayout;
+import mezz.jei.api.gui.builder.IIngredientAcceptor;
+import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
+import mezz.jei.api.gui.builder.IRecipeSlotBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.gui.drawable.IDrawableAnimated;
-import mezz.jei.api.gui.ingredient.IGuiItemStackGroup;
+import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
 import mezz.jei.api.helpers.IGuiHelper;
-import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.recipe.IFocusGroup;
+import mezz.jei.api.recipe.RecipeIngredientRole;
+import mezz.jei.api.recipe.RecipeType;
 import mezz.jei.api.recipe.category.IRecipeCategory;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class ImplosionCompressionCategory implements IRecipeCategory<ImplosionCompressorRecipe> {
 
@@ -37,17 +38,24 @@ public class ImplosionCompressionCategory implements IRecipeCategory<ImplosionCo
         // 68, 12 | 40, 65 -> 10 px added for chance
         ResourceLocation GUI = new ResourceLocation(VoluminousEnergy.MODID, "textures/gui/jei/jei.png");
         background = guiHelper.drawableBuilder(GUI, 68, 12, 70, 40).build();
-        icon = guiHelper.createDrawableIngredient(new ItemStack(VEBlocks.IMPLOSION_COMPRESSOR_BLOCK));
+        icon = guiHelper.createDrawableIngredient(VanillaTypes.ITEM, new ItemStack(VEBlocks.IMPLOSION_COMPRESSOR_BLOCK));
         slotDrawable = guiHelper.getSlotDrawable();
         arrow = guiHelper.drawableBuilder(GUI, 176, 0, 23, 17).build();
         emptyArrow = guiHelper.drawableBuilder(GUI,199,0,23,17).buildAnimated(200, IDrawableAnimated.StartDirection.LEFT, true);
     }
 
     @Override
+    public @NotNull RecipeType getRecipeType(){
+        return new RecipeType(VoluminousEnergyPlugin.IMPLOSION_COMPRESSION_UID, ImplosionCompressorRecipe.class);
+    }
+
+    @Deprecated
+    @Override
     public ResourceLocation getUid(){
         return VoluminousEnergyPlugin.IMPLOSION_COMPRESSION_UID;
     }
 
+    @Deprecated
     @Override
     public Class<? extends ImplosionCompressorRecipe> getRecipeClass() {
         return ImplosionCompressorRecipe.class;
@@ -69,7 +77,7 @@ public class ImplosionCompressionCategory implements IRecipeCategory<ImplosionCo
     }
 
     @Override
-    public void draw(ImplosionCompressorRecipe recipe, PoseStack matrixStack, double mouseX, double mouseY) {
+    public void draw(ImplosionCompressorRecipe recipe, IRecipeSlotsView recipeSlotsView, PoseStack matrixStack, double mouseX, double mouseY) {
         arrow.draw(matrixStack,24, 12);
         emptyArrow.draw(matrixStack,24,12);
         slotDrawable.draw(matrixStack,2,1);
@@ -77,48 +85,41 @@ public class ImplosionCompressionCategory implements IRecipeCategory<ImplosionCo
         slotDrawable.draw(matrixStack,48,10);
     }
 
-    @Override
-    public void setIngredients(ImplosionCompressorRecipe recipe, IIngredients ingredients) {
-        ingredients.setInputLists(VanillaTypes.ITEM, recipe.getIngredientMap().keySet().stream()
-                .map(ingredient -> Arrays.asList(ingredient.getItems()))
-                .collect(Collectors.toList()));
-
-        // STACK needs to be 64 for recipes that require more than 1 of the input item
-        // This for loop ensures that every input can be right clicked, maybe it can just fetch the current ingredient
-        // to save CPU cycles... but this works.
-        for (ItemStack testStack : recipe.getIngredient().getItems()){
-            testStack.setCount(64);
-            ingredients.setInput(VanillaTypes.ITEM, testStack);
+    public void ingredientHandler(ImplosionCompressorRecipe recipe,
+                                  IIngredientAcceptor itemInputAcceptor,
+                                  IIngredientAcceptor explosiveInputAcceptor,
+                                  IIngredientAcceptor itemOutputAcceptor) {
+        // Input
+        ArrayList<ItemStack> inputStacks = new ArrayList<>();
+        for (ItemStack itemStack : recipe.ingredient.get().getItems()){
+            itemStack.setCount(recipe.getIngredientCount());
+            inputStacks.add(itemStack);
         }
 
-        // OUTPUT
-        List<ItemStack> outputStacks = new ArrayList<>();
-        outputStacks.add(recipe.getResultItem()); // Normal output
+        itemInputAcceptor.addIngredients(VanillaTypes.ITEM, inputStacks);
 
-        ingredients.setOutputs(VanillaTypes.ITEM, outputStacks);
+        // Explosive input
+        explosiveInputAcceptor.addIngredient(VanillaTypes.ITEM, new ItemStack(Items.GUNPOWDER, recipe.ingredientCount));
+
+        // Output
+        ItemStack resultStack = recipe.result;
+        resultStack.setCount(recipe.getOutputAmount());
+        itemOutputAcceptor.addIngredient(VanillaTypes.ITEM, resultStack);
     }
 
     @Override
-    public void setRecipe(IRecipeLayout recipeLayout, ImplosionCompressorRecipe recipe, IIngredients ingredients) {
-        IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
-        itemStacks.init(0, true, 2, 1);
-        itemStacks.init(2, true, 2, 19);
-        itemStacks.init(1, false, 48, 10);
+    public void setRecipe(IRecipeLayoutBuilder recipeLayout, ImplosionCompressorRecipe recipe, IFocusGroup focusGroup) {
+        // Input
+        IRecipeSlotBuilder itemInput = recipeLayout.addSlot(RecipeIngredientRole.INPUT, 3, 2);
+        IRecipeSlotBuilder explosiveInput = recipeLayout.addSlot(RecipeIngredientRole.INPUT, 3, 20);
 
-        // Should only be one ingredient...
-        List<ItemStack> inputs = new ArrayList<>();
-        Arrays.stream(recipe.getIngredient().getItems()).map(s -> {
-            ItemStack stack = s.copy();
-            stack.setCount(recipe.getIngredientCount());
-            return stack;
-        }).forEach(inputs::add);
-        itemStacks.set(0, inputs);
+        // Output
+        IRecipeSlotBuilder itemOutput = recipeLayout.addSlot(RecipeIngredientRole.OUTPUT, 49, 11);
 
-        // Calculate output
-        ItemStack tempStack = recipe.getResultItem(); // Get Item since amount will be wrong
-        Item outputItem = tempStack.getItem();
-        ItemStack jeiStack = new ItemStack(outputItem, recipe.getOutputAmount()); // Create new stack for JEI with correct amount
-        itemStacks.set(1, jeiStack);
-        itemStacks.set(2, new ItemStack(Items.GUNPOWDER, 1));
+        itemInput.setSlotName(TextUtil.TRANSLATED_INPUT_SLOT.getString());
+        explosiveInput.setSlotName(TextUtil.TRANSLATED_INPUT_SLOT.getString());
+        itemOutput.setSlotName(TextUtil.TRANSLATED_OUTPUT_SLOT.getString());
+
+        this.ingredientHandler(recipe, itemInput, explosiveInput, itemOutput);
     }
 }

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/category/ImplosionCompressionCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/category/ImplosionCompressionCategory.java
@@ -33,6 +33,7 @@ public class ImplosionCompressionCategory implements IRecipeCategory<ImplosionCo
     private IDrawable slotDrawable;
     private IDrawable arrow;
     private IDrawable emptyArrow;
+    public static final RecipeType RECIPE_TYPE = new RecipeType(VoluminousEnergyPlugin.IMPLOSION_COMPRESSION_UID, ImplosionCompressorRecipe.class);
 
     public ImplosionCompressionCategory(IGuiHelper guiHelper){
         // 68, 12 | 40, 65 -> 10 px added for chance
@@ -46,7 +47,7 @@ public class ImplosionCompressionCategory implements IRecipeCategory<ImplosionCo
 
     @Override
     public @NotNull RecipeType getRecipeType(){
-        return new RecipeType(VoluminousEnergyPlugin.IMPLOSION_COMPRESSION_UID, ImplosionCompressorRecipe.class);
+        return RECIPE_TYPE;
     }
 
     @Deprecated

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/category/ImplosionCompressionCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/category/ImplosionCompressionCategory.java
@@ -102,7 +102,7 @@ public class ImplosionCompressionCategory implements IRecipeCategory<ImplosionCo
         explosiveInputAcceptor.addIngredient(VanillaTypes.ITEM, new ItemStack(Items.GUNPOWDER, recipe.ingredientCount));
 
         // Output
-        ItemStack resultStack = recipe.result;
+        ItemStack resultStack = recipe.result.copy();
         resultStack.setCount(recipe.getOutputAmount());
         itemOutputAcceptor.addIngredient(VanillaTypes.ITEM, resultStack);
     }

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/category/IndustrialBlastingCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/category/IndustrialBlastingCategory.java
@@ -37,6 +37,7 @@ public class IndustrialBlastingCategory implements IRecipeCategory<IndustrialBla
     private IDrawable slotDrawable;
     private IDrawable arrow;
     private IDrawable emptyArrow;
+    public static final RecipeType RECIPE_TYPE = new RecipeType(VoluminousEnergyPlugin.INDUSTRIAL_BLASTING_UID, IndustrialBlastingRecipe.class);
 
     public IndustrialBlastingCategory(IGuiHelper guiHelper){
         // 68, 12 | 40, 65 -> 10 px added for chance
@@ -50,7 +51,7 @@ public class IndustrialBlastingCategory implements IRecipeCategory<IndustrialBla
 
     @Override
     public @NotNull RecipeType getRecipeType(){
-        return new RecipeType(VoluminousEnergyPlugin.INDUSTRIAL_BLASTING_UID, IndustrialBlastingRecipe.class);
+        return RECIPE_TYPE;
     }
 
     @Deprecated

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/category/StirlingCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/category/StirlingCategory.java
@@ -31,6 +31,7 @@ public class StirlingCategory implements IRecipeCategory<StirlingGeneratorRecipe
     private final IDrawable background;
     private IDrawable icon;
     private IDrawable slotDrawable;
+    public static final RecipeType RECIPE_TYPE = new RecipeType(VoluminousEnergyPlugin.STIRLING_UID, StirlingGeneratorRecipe.class);
 
     public StirlingCategory(IGuiHelper guiHelper){
         // 68, 12 | 40, 65 -> 10 px added for chance
@@ -42,7 +43,7 @@ public class StirlingCategory implements IRecipeCategory<StirlingGeneratorRecipe
 
     @Override
     public @NotNull RecipeType getRecipeType(){
-        return new RecipeType(VoluminousEnergyPlugin.STIRLING_UID, StirlingGeneratorRecipe.class);
+        return RECIPE_TYPE;
     }
 
     @Deprecated

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/category/StirlingCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/category/StirlingCategory.java
@@ -12,6 +12,7 @@ import mezz.jei.api.gui.builder.IIngredientAcceptor;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.builder.IRecipeSlotBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
+import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
 import mezz.jei.api.helpers.IGuiHelper;
 import mezz.jei.api.recipe.IFocusGroup;
 import mezz.jei.api.recipe.RecipeIngredientRole;
@@ -72,7 +73,7 @@ public class StirlingCategory implements IRecipeCategory<StirlingGeneratorRecipe
     }
 
     @Override
-    public void draw(StirlingGeneratorRecipe recipe, PoseStack matrixStack, double mouseX, double mouseY) {
+    public void draw(StirlingGeneratorRecipe recipe, IRecipeSlotsView recipeSlotsView, PoseStack matrixStack, double mouseX, double mouseY) {
         slotDrawable.draw(matrixStack,11,0);
         Minecraft.getInstance().font.draw(matrixStack,recipe.getEnergyPerTick() + " FE/t",-1,20, VEContainerScreen.GREY_TEXT_COLOUR);
         Minecraft.getInstance().font.draw(matrixStack,recipe.getProcessTime() + " t",-1,28, VEContainerScreen.GREY_TEXT_COLOUR);

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/category/StirlingCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/category/StirlingCategory.java
@@ -3,25 +3,27 @@ package com.veteam.voluminousenergy.compat.jei.category;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.veteam.voluminousenergy.VoluminousEnergy;
 import com.veteam.voluminousenergy.blocks.blocks.VEBlocks;
+import com.veteam.voluminousenergy.blocks.screens.VEContainerScreen;
 import com.veteam.voluminousenergy.compat.jei.VoluminousEnergyPlugin;
 import com.veteam.voluminousenergy.recipe.StirlingGeneratorRecipe;
 import com.veteam.voluminousenergy.util.TextUtil;
 import mezz.jei.api.constants.VanillaTypes;
-import mezz.jei.api.gui.IRecipeLayout;
+import mezz.jei.api.gui.builder.IIngredientAcceptor;
+import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
+import mezz.jei.api.gui.builder.IRecipeSlotBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
-import mezz.jei.api.gui.ingredient.IGuiItemStackGroup;
 import mezz.jei.api.helpers.IGuiHelper;
-import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.recipe.IFocusGroup;
+import mezz.jei.api.recipe.RecipeIngredientRole;
+import mezz.jei.api.recipe.RecipeType;
 import mezz.jei.api.recipe.category.IRecipeCategory;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class StirlingCategory implements IRecipeCategory<StirlingGeneratorRecipe> {
 
@@ -33,15 +35,22 @@ public class StirlingCategory implements IRecipeCategory<StirlingGeneratorRecipe
         // 68, 12 | 40, 65 -> 10 px added for chance
         ResourceLocation GUI = new ResourceLocation(VoluminousEnergy.MODID, "textures/gui/jei/combustion_generator.png");
         background = guiHelper.drawableBuilder(GUI, 68, 12, 40, 44).build();
-        icon = guiHelper.createDrawableIngredient(new ItemStack(VEBlocks.STIRLING_GENERATOR_BLOCK));
+        icon = guiHelper.createDrawableIngredient(VanillaTypes.ITEM, new ItemStack(VEBlocks.STIRLING_GENERATOR_BLOCK));
         slotDrawable = guiHelper.getSlotDrawable();
     }
 
+    @Override
+    public @NotNull RecipeType getRecipeType(){
+        return new RecipeType(VoluminousEnergyPlugin.STIRLING_UID, StirlingGeneratorRecipe.class);
+    }
+
+    @Deprecated
     @Override
     public ResourceLocation getUid(){
         return VoluminousEnergyPlugin.STIRLING_UID;
     }
 
+    @Deprecated
     @Override
     public Class<? extends StirlingGeneratorRecipe> getRecipeClass() {
         return StirlingGeneratorRecipe.class;
@@ -65,38 +74,21 @@ public class StirlingCategory implements IRecipeCategory<StirlingGeneratorRecipe
     @Override
     public void draw(StirlingGeneratorRecipe recipe, PoseStack matrixStack, double mouseX, double mouseY) {
         slotDrawable.draw(matrixStack,11,0);
-        Minecraft.getInstance().font.draw(matrixStack,recipe.getEnergyPerTick() + " FE/t",-1,20, 0x606060);
-        Minecraft.getInstance().font.draw(matrixStack,recipe.getProcessTime() + " t",-1,28, 0x606060);
-        Minecraft.getInstance().font.draw(matrixStack,recipe.getProcessTime()/20 + " sec",-1,36, 0x606060);
+        Minecraft.getInstance().font.draw(matrixStack,recipe.getEnergyPerTick() + " FE/t",-1,20, VEContainerScreen.GREY_TEXT_COLOUR);
+        Minecraft.getInstance().font.draw(matrixStack,recipe.getProcessTime() + " t",-1,28, VEContainerScreen.GREY_TEXT_COLOUR);
+        Minecraft.getInstance().font.draw(matrixStack,recipe.getProcessTime()/20 + " sec",-1,36, VEContainerScreen.GREY_TEXT_COLOUR);
+    }
+
+    public void ingredientHandler(StirlingGeneratorRecipe recipe, IIngredientAcceptor itemInputAcceptor) {
+        itemInputAcceptor.addIngredients(VanillaTypes.ITEM, Arrays.stream(recipe.ingredient.get().getItems()).toList());
     }
 
     @Override
-    public void setIngredients(StirlingGeneratorRecipe recipe, IIngredients ingredients) {
-        ingredients.setInputLists(VanillaTypes.ITEM, recipe.getIngredientMap().keySet().stream()
-                .map(ingredient -> Arrays.asList(ingredient.getItems()))
-                .collect(Collectors.toList()));
+    public void setRecipe(IRecipeLayoutBuilder recipeLayout, StirlingGeneratorRecipe recipe, IFocusGroup focusGroup) {
+        // Inputs
+        IRecipeSlotBuilder itemInput = recipeLayout.addSlot(RecipeIngredientRole.INPUT, 12, 1);
 
-        // STACK needs to be 64 for recipes that require more than 1 of the input item
-        // This for loop ensures that every input can be right clicked, maybe it can just fetch the current ingredient
-        // to save CPU cycles... but this works.
-        for (ItemStack testStack : recipe.getIngredient().getItems()){
-            testStack.setCount(64);
-            ingredients.setInput(VanillaTypes.ITEM, testStack);
-        }
-    }
-
-    @Override
-    public void setRecipe(IRecipeLayout recipeLayout, StirlingGeneratorRecipe recipe, IIngredients ingredients) {
-        IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
-        itemStacks.init(0, true, 11, 0);
-
-        // Should only be one ingredient...
-        List<ItemStack> inputs = new ArrayList<>();
-        Arrays.stream(recipe.getIngredient().getItems()).map(s -> {
-            ItemStack stack = s.copy();
-            stack.setCount(recipe.getIngredientCount());
-            return stack;
-        }).forEach(inputs::add);
-        itemStacks.set(0, inputs);
+        itemInput.setSlotName(TextUtil.TRANSLATED_INPUT_SLOT.getString());
+        this.ingredientHandler(recipe, itemInput);
     }
 }

--- a/src/main/java/com/veteam/voluminousenergy/compat/jei/category/ToolingCategory.java
+++ b/src/main/java/com/veteam/voluminousenergy/compat/jei/category/ToolingCategory.java
@@ -32,7 +32,7 @@ public class ToolingCategory implements IRecipeCategory<ToolingRecipe> {
     private IDrawable icon;
     private IDrawable slotDrawable;
     private IDrawable arrow;
-    private IDrawable arrowRotated;
+    public static final RecipeType RECIPE_TYPE = new RecipeType(VoluminousEnergyPlugin.TOOLING_UID, ToolingRecipe.class);
 
     public ToolingCategory(IGuiHelper guiHelper){
         // 68, 12 | 40, 65 -> 10 px added for chance
@@ -46,7 +46,7 @@ public class ToolingCategory implements IRecipeCategory<ToolingRecipe> {
 
     @Override
     public @NotNull RecipeType getRecipeType(){
-        return new RecipeType(VoluminousEnergyPlugin.TOOLING_UID, ToolingRecipe.class);
+        return RECIPE_TYPE;
     }
 
     @Deprecated

--- a/src/main/java/com/veteam/voluminousenergy/recipe/AqueoulizerRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/AqueoulizerRecipe.java
@@ -140,8 +140,10 @@ public class AqueoulizerRecipe extends VEFluidRecipe {
         public AqueoulizerRecipe fromJson(ResourceLocation recipeId, JsonObject json) {
             AqueoulizerRecipe recipe = new AqueoulizerRecipe(recipeId);
 
-            recipe.ingredient = Lazy.of(() -> Ingredient.fromJson(json.get("ingredient")));
-            recipe.ingredientCount = GsonHelper.getAsInt(json.get("ingredient").getAsJsonObject(), "count", 1);
+            JsonObject ingredientJson = json.get("ingredient").getAsJsonObject();
+
+            recipe.ingredient = Lazy.of(() -> Ingredient.fromJson(ingredientJson));
+            recipe.ingredientCount = GsonHelper.getAsInt(ingredientJson, "count", 1);
             recipe.processTime = GsonHelper.getAsInt(json,"process_time",200);
 
             JsonObject inputFluid = json.get("input_fluid").getAsJsonObject();

--- a/src/main/java/com/veteam/voluminousenergy/recipe/CentrifugalAgitatorRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/CentrifugalAgitatorRecipe.java
@@ -146,8 +146,10 @@ public class CentrifugalAgitatorRecipe extends VEFluidRecipe {
         public CentrifugalAgitatorRecipe fromJson(ResourceLocation recipeId, JsonObject json) {
             CentrifugalAgitatorRecipe recipe = new CentrifugalAgitatorRecipe(recipeId);
 
-            recipe.ingredient = Lazy.of(() -> Ingredient.fromJson(json.get("ingredient")));
-            recipe.ingredientCount = GsonHelper.getAsInt(json.get("ingredient").getAsJsonObject(), "count", 1);
+            JsonObject ingredientJson = json.get("ingredient").getAsJsonObject();
+
+            recipe.ingredient = Lazy.of(() -> Ingredient.fromJson(ingredientJson));
+            recipe.ingredientCount = GsonHelper.getAsInt(ingredientJson, "count", 1);
 
             recipe.processTime = GsonHelper.getAsInt(json,"process_time",200);
 

--- a/src/main/java/com/veteam/voluminousenergy/recipe/CentrifugalSeparatorRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/CentrifugalSeparatorRecipe.java
@@ -119,8 +119,10 @@ public class CentrifugalSeparatorRecipe extends VERecipe{
         public CentrifugalSeparatorRecipe fromJson(ResourceLocation recipeId, JsonObject json){
             CentrifugalSeparatorRecipe recipe = new CentrifugalSeparatorRecipe(recipeId);
 
-            recipe.ingredient = Lazy.of(() -> Ingredient.fromJson(json.get("ingredient")));
-            recipe.ingredientCount = GsonHelper.getAsInt(json.get("ingredient").getAsJsonObject(), "count", 1);
+            JsonObject ingredientJson = json.get("ingredient").getAsJsonObject();
+
+            recipe.ingredient = Lazy.of(() -> Ingredient.fromJson(ingredientJson));
+            recipe.ingredientCount = GsonHelper.getAsInt(ingredientJson, "count", 1);
             recipe.processTime = GsonHelper.getAsInt(json,"process_time",200);
 
             // Main Output Slot

--- a/src/main/java/com/veteam/voluminousenergy/recipe/CompressorRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/CompressorRecipe.java
@@ -107,8 +107,10 @@ public class CompressorRecipe extends VERecipe {
 
             CompressorRecipe recipe = new CompressorRecipe(recipeId);
 
-            recipe.ingredient = Lazy.of(() -> Ingredient.fromJson(json.get("ingredient")));
-            recipe.ingredientCount = GsonHelper.getAsInt(json.get("ingredient").getAsJsonObject(),"count",1);
+            JsonObject ingredientJson = json.get("ingredient").getAsJsonObject();
+
+            recipe.ingredient = Lazy.of(() -> Ingredient.fromJson(ingredientJson));
+            recipe.ingredientCount = GsonHelper.getAsInt(ingredientJson, "count", 1);
             recipe.processTime = GsonHelper.getAsInt(json, "process_time", 200);
 
             ResourceLocation itemResourceLocation = ResourceLocation.of(GsonHelper.getAsString(json.get("result").getAsJsonObject(), "item", "minecraft:air"),':');

--- a/src/main/java/com/veteam/voluminousenergy/recipe/CrusherRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/CrusherRecipe.java
@@ -99,8 +99,10 @@ public class CrusherRecipe extends VERecipe {
         public CrusherRecipe fromJson(ResourceLocation recipeId, JsonObject json){
             CrusherRecipe recipe = new CrusherRecipe(recipeId);
 
-            recipe.ingredient = Lazy.of(() -> Ingredient.fromJson(json.get("ingredient")));
-            recipe.ingredientCount = GsonHelper.getAsInt(json.get("ingredient").getAsJsonObject(), "count", 1);
+            JsonObject ingredientJson = json.get("ingredient").getAsJsonObject();
+
+            recipe.ingredient = Lazy.of(() -> Ingredient.fromJson(ingredientJson));
+            recipe.ingredientCount = GsonHelper.getAsInt(ingredientJson, "count", 1);
             recipe.processTime = GsonHelper.getAsInt(json,"process_time",200);
 
             ResourceLocation itemResourceLocation = ResourceLocation.of(GsonHelper.getAsString(json.get("result").getAsJsonObject(),"item","minecraft:air"),':');

--- a/src/main/java/com/veteam/voluminousenergy/recipe/DistillationRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/DistillationRecipe.java
@@ -167,8 +167,10 @@ public class DistillationRecipe extends VEFluidRecipe {
         public DistillationRecipe fromJson(ResourceLocation recipeId, JsonObject json) {
             DistillationRecipe recipe = new DistillationRecipe(recipeId);
 
-            recipe.ingredient = Lazy.of(() -> Ingredient.fromJson(json.get("ingredient")));
-            recipe.ingredientCount = GsonHelper.getAsInt(json.get("ingredient").getAsJsonObject(), "count", 1);
+            JsonObject ingredientJson = json.get("ingredient").getAsJsonObject();
+
+            recipe.ingredient = Lazy.of(() -> Ingredient.fromJson(ingredientJson));
+            recipe.ingredientCount = GsonHelper.getAsInt(ingredientJson, "count", 1);
             recipe.inputAmount = GsonHelper.getAsInt(json.get("ingredient").getAsJsonObject(), "amount", 0);
             recipe.processTime = GsonHelper.getAsInt(json,"process_time",200);
 

--- a/src/main/java/com/veteam/voluminousenergy/recipe/ElectrolyzerRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/ElectrolyzerRecipe.java
@@ -119,8 +119,10 @@ public class ElectrolyzerRecipe extends VERecipe {
         public ElectrolyzerRecipe fromJson(ResourceLocation recipeId, JsonObject json){
             ElectrolyzerRecipe recipe = new ElectrolyzerRecipe(recipeId);
 
-            recipe.ingredient = Lazy.of(() -> Ingredient.fromJson(json.get("ingredient")));
-            recipe.ingredientCount = GsonHelper.getAsInt(json.get("ingredient").getAsJsonObject(), "count", 1);
+            JsonObject ingredientJson = json.get("ingredient").getAsJsonObject();
+
+            recipe.ingredient = Lazy.of(() -> Ingredient.fromJson(ingredientJson));
+            recipe.ingredientCount = GsonHelper.getAsInt(ingredientJson, "count", 1);
             recipe.processTime = GsonHelper.getAsInt(json,"process_time",200);
 
             // Main Output Slot

--- a/src/main/java/com/veteam/voluminousenergy/recipe/ImplosionCompressorRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/ImplosionCompressorRecipe.java
@@ -107,8 +107,10 @@ public class ImplosionCompressorRecipe extends VERecipe {
 
             ImplosionCompressorRecipe recipe = new ImplosionCompressorRecipe(recipeId);
 
-            recipe.ingredient = Lazy.of(() -> Ingredient.fromJson(json.get("ingredient")));
-            recipe.ingredientCount = GsonHelper.getAsInt(json.get("ingredient").getAsJsonObject(),"count",1);
+            JsonObject ingredientJson = json.get("ingredient").getAsJsonObject();
+
+            recipe.ingredient = Lazy.of(() -> Ingredient.fromJson(ingredientJson));
+            recipe.ingredientCount = GsonHelper.getAsInt(ingredientJson, "count", 1);
             recipe.processTime = GsonHelper.getAsInt(json, "process_time", 200);
 
             ResourceLocation itemResourceLocation = ResourceLocation.of(GsonHelper.getAsString(json.get("result").getAsJsonObject(), "item", "minecraft:air"),':');

--- a/src/main/java/com/veteam/voluminousenergy/recipe/IndustrialBlastingRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/IndustrialBlastingRecipe.java
@@ -82,6 +82,11 @@ public class IndustrialBlastingRecipe extends VERecipe {
 
     public int getProcessTime(){ return processTime; }
 
+    @Override
+    public int getIngredientCount() {
+        return this.ingredientCount != 0 ? this.ingredientCount : (tempIngredientCount.get() > 0 ? tempIngredientCount.get() : 1);
+    }
+
     public int getMinimumHeat(){ return minimumHeat; }
 
     public int getSecondInputAmount() {return secondInputAmount;}
@@ -184,6 +189,7 @@ public class IndustrialBlastingRecipe extends VERecipe {
             for (int i = 0; i < firstInputSize; i++){
                 ItemStack readStack = buffer.readItem();
                 firstInputList.add(readStack.getItem());
+                recipe.ingredientCount = readStack.getCount();
             }
             recipe.ingredientList = Lazy.of(() -> firstInputList);
 

--- a/src/main/java/com/veteam/voluminousenergy/recipe/StirlingGeneratorRecipe.java
+++ b/src/main/java/com/veteam/voluminousenergy/recipe/StirlingGeneratorRecipe.java
@@ -107,8 +107,10 @@ public class StirlingGeneratorRecipe extends VERecipe {
 
             StirlingGeneratorRecipe recipe = new StirlingGeneratorRecipe(recipeId);
 
-            recipe.ingredient = Lazy.of(() -> Ingredient.fromJson(json.get("ingredient")));
-            recipe.ingredientCount = GsonHelper.getAsInt(json.get("ingredient").getAsJsonObject(),"count",1);
+            JsonObject ingredientJson = json.get("ingredient").getAsJsonObject();
+
+            recipe.ingredient = Lazy.of(() -> Ingredient.fromJson(ingredientJson));
+            recipe.ingredientCount = GsonHelper.getAsInt(ingredientJson, "count", 1);
             recipe.processTime = GsonHelper.getAsInt(json, "process_time", 200);
             recipe.energyPerTick  = GsonHelper.getAsInt(json, "energy_per_tick", Config.STIRLING_GENERATOR_GENERATE.get());
 

--- a/src/main/java/com/veteam/voluminousenergy/util/NumberUtil.java
+++ b/src/main/java/com/veteam/voluminousenergy/util/NumberUtil.java
@@ -54,6 +54,26 @@ public class NumberUtil {
         }
     }
 
+    public static String numberToString4FE(double num) {
+        if (num < 1_000) {
+            String toReturn = String.valueOf(num);
+            toReturn += " FE";
+            return toReturn;
+        } else if (num >= 1_000 && num < 1_000_000d) {
+            return removeZeros(num / 1_000) + " kFE";
+        } else if (num < 1_000_000_000d) {
+            return removeZeros(num / 1_000_000d) + " MFE";
+        } else if (num < 1_000_000_000_000d) {
+            return removeZeros(num / 1_000_000_000d) + " GFE";
+        } else {
+            return removeZeros(num / 1_000_000_000_000d) + " TFE";
+        }
+    }
+
+    public static Component numberToTextComponent4FE(double num){
+        return new TextComponent(numberToString4FE(num));
+    }
+
     public static Component numberToTextComponent4Fluids(double num){
         return new TextComponent(numberToString4Fluids(num));
     }

--- a/src/main/java/com/veteam/voluminousenergy/util/RecipeUtil.java
+++ b/src/main/java/com/veteam/voluminousenergy/util/RecipeUtil.java
@@ -302,6 +302,20 @@ public class RecipeUtil {
         return fluidList.get();
     }
 
+    public static CombustionGeneratorOxidizerRecipe getOxidizerCombustionRecipeWithoutLevel(FluidStack fluidStack){
+        return getOxidizerCombustionRecipeWithoutLevel(fluidStack.getRawFluid());
+    }
+
+    public static CombustionGeneratorOxidizerRecipe getOxidizerCombustionRecipeWithoutLevel(Fluid fluid){
+        AtomicReference<CombustionGeneratorOxidizerRecipe> recipeToReturn = new AtomicReference<>(null);
+        CombustionGeneratorOxidizerRecipe.oxidizerRecipes.parallelStream().forEach(oxidizerRecipe -> {
+            if (oxidizerRecipe.rawFluidInputList.get().contains(fluid)){
+                recipeToReturn.set(oxidizerRecipe);
+            }
+        });
+        return recipeToReturn.get();
+    }
+
     public static IndustrialBlastingRecipe getIndustrialBlastingRecipe(Level world, ItemStack firstInput, ItemStack secondInput){
         if(firstInput.isEmpty() || secondInput.isEmpty()) return null;
         for (Recipe<?> recipe : world.getRecipeManager().getRecipes()){

--- a/src/main/java/com/veteam/voluminousenergy/util/RecipeUtil.java
+++ b/src/main/java/com/veteam/voluminousenergy/util/RecipeUtil.java
@@ -3,6 +3,7 @@ package com.veteam.voluminousenergy.util;
 import com.veteam.voluminousenergy.recipe.*;
 import com.veteam.voluminousenergy.recipe.CombustionGenerator.CombustionGeneratorFuelRecipe;
 import com.veteam.voluminousenergy.recipe.CombustionGenerator.CombustionGeneratorOxidizerRecipe;
+import com.veteam.voluminousenergy.tools.Config;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -619,5 +620,17 @@ public class RecipeUtil {
             if (lazyPair.get().getA().contains(fluid)) atomicInteger.set(lazyPair.get().getB());
         });
         return atomicInteger.get();
+    }
+
+    public static ArrayList<FluidStack> getFluidsAsHotOrHotterThanIntAsFluidStacks(int minimumTemperatureKelvin, int stackAmount){
+        AtomicReference<ArrayList<FluidStack>> fluidStacks = new AtomicReference<>(new ArrayList<>());
+        ForgeRegistries.FLUIDS.getValues().parallelStream().forEach(fluid -> {
+            if (fluid.getAttributes().getTemperature() > minimumTemperatureKelvin) fluidStacks.get().add(new FluidStack(fluid, stackAmount));
+        });
+        return fluidStacks.get();
+    }
+
+    public static ArrayList<FluidStack> getFluidsHotEnoughForIndustrialBlastingRecipe(IndustrialBlastingRecipe recipe){
+        return getFluidsAsHotOrHotterThanIntAsFluidStacks(recipe.getMinimumHeat(), Config.BLAST_FURNACE_HEAT_SOURCE_CONSUMPTION.get());
     }
 }

--- a/src/main/java/com/veteam/voluminousenergy/util/TextUtil.java
+++ b/src/main/java/com/veteam/voluminousenergy/util/TextUtil.java
@@ -11,6 +11,17 @@ public class TextUtil {
     *   ITextComponent textComponent = ITextComponent.getTextComponentOrEmpty(", " + amount + " mB / " + tankCapacity + " mB");
     *   return name.append(textComponent);
     */
+    // Slots
+    public static Component TRANSLATED_INPUT_SLOT = TextUtil.translateString("slot.voluminousenergy.input_slot");
+    public static Component TRANSLATED_OUTPUT_SLOT = TextUtil.translateString("slot.voluminousenergy.output_slot");
+    public static Component TRANSLATED_RNG_SLOT = TextUtil.translateString("slot.voluminousenergy.rng_slot");
+    public static Component TRANSLATED_BUCKET_SLOT = TextUtil.translateString("slot.voluminousenergy.bucket_slot");
+
+    // Tanks
+    public static Component TRANSLATED_INPUT_TANK = TextUtil.translateString("tank.voluminousenergy.input_tank");
+    public static Component TRANSLATED_OUTPUT_TANK = TextUtil.translateString("tank.voluminousenergy.output_tank");
+    public static Component TRANSLATED_BOTH_TANK = TextUtil.translateString("tank.voluminousenergy.both_tank");
+
     public static Component tankTooltip(String fluidName, int amount, int tankCapacity){
         return new TranslatableComponent(fluidName).append(Component.nullToEmpty(", " + amount + " mB / " + tankCapacity + " mB"));
     }

--- a/src/main/java/com/veteam/voluminousenergy/util/TextUtil.java
+++ b/src/main/java/com/veteam/voluminousenergy/util/TextUtil.java
@@ -6,11 +6,7 @@ import net.minecraft.network.chat.TextComponent;
 import net.minecraft.network.chat.TranslatableComponent;
 
 public class TextUtil {
-    /*
-    *   TranslationTextComponent name = new TranslationTextComponent(fluidName);
-    *   ITextComponent textComponent = ITextComponent.getTextComponentOrEmpty(", " + amount + " mB / " + tankCapacity + " mB");
-    *   return name.append(textComponent);
-    */
+
     // Slots
     public static Component TRANSLATED_INPUT_SLOT = TextUtil.translateString("slot.voluminousenergy.input_slot");
     public static Component TRANSLATED_OUTPUT_SLOT = TextUtil.translateString("slot.voluminousenergy.output_slot");

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -40,9 +40,16 @@ description='''Voluminous Energy - A Tech mod focused on resource processing and
     side="BOTH"
 
 # Here's another dependency
-[[dependencies.examplemod]]
+[[dependencies.voluminousenergy]]
     modId="minecraft"
     mandatory=true
     versionRange="[1.18.2,1.19)"
     ordering="NONE"
     side="BOTH"
+
+[[dependencies.voluminousenergy]]
+    modId="jei"
+    mandatory=false
+    versionRange="[9.5.2.134,)"
+    ordering="NONE"
+    side="CLIENT"

--- a/src/main/resources/assets/voluminousenergy/lang/en_us.json
+++ b/src/main/resources/assets/voluminousenergy/lang/en_us.json
@@ -348,5 +348,12 @@
     "_comment": "JEI UI Info",
     "jei.voluminousenergy.crude_oil_info": "Crude Oil can be obtained either from Oil Geysers, Oil Lakes, or Soul Sand in the Centrifugal Separator",
     "jei.voluminousenergy.air_compressor_fluid_info": "Compressed Air can be obtained via the Air Compressor",
-    "jei.voluminousenergy.air_compressor_item_info": "Compressed Air can be obtained via the Air Compressor; The Air Compressor produces Compressed Air"
+    "jei.voluminousenergy.air_compressor_item_info": "Compressed Air can be obtained via the Air Compressor; The Air Compressor produces Compressed Air",
+
+    "_comment": "JEI Fluid Types for Combustion",
+    "jei.voluminousenergy.fluid.fuel": "Fuel",
+    "jei.voluminousenergy.fluid.oxidizer": "Oxidizer",
+
+    "_comment": "JEI Misc",
+    "jei.voluminousenergy.volumetric_energy": "Volumetric Energy"
 }


### PR DESCRIPTION
This PR updates all of the categories such that they no longer use deprecated calls in JEI that are marked for removal, with the exception of those that JEI still requires to be implemented. Despite the fact that `getUid` and `getRecipeClass` are still required, these are no longer used within the Voluminous Energy JEI plugin, are marked as deprecated, and will be removed when they're no longer required to be implemented by JEI.

This PR also fixes the CTD with the Air Compressor. 